### PR TITLE
feat: migrate /get_rta_core from SWRT to Lucksack

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,18 @@ Supported modes:
 - `Anonymized`
 - `NoSpeedDetailAndAnonymized`
 
-### `/get_rta_core <file> <rank> [monster] <mode>`
+### `/get_rta_core <file> <rank> [monster] [exclude] [sort] [min_games]`
 
-Computes top trios from your box and current meta data.
+Computes the best trios you can field from your account box, using live trio statistics from Lucksack for the selected rank and current patch. Only trios whose three monsters are all in your box are shown.
 
 Supported rank values:
-- `C1`, `C2`, `C3`, `P1`, `P2`, `P3`, `G1`, `G2`, `G3`
+- `P1`, `P2-P3`, `G1-G3`, `G3`
 
-Supported mode values:
-- `MetaSlayer`
-- `FunAndCasual`
+Optional parameters:
+- `monster`: focus on trios containing this monster (uses Lucksack's per-monster trios).
+- `exclude`: hide trios containing this monster.
+- `sort`: `Most Played` or `Best Winrate` (default: 5 of each).
+- `min_games`: minimum games per trio for reliability (default: 50).
 
 ### `/track_player_names <mode>`
 

--- a/src/commands/rta_core/cache.rs
+++ b/src/commands/rta_core/cache.rs
@@ -1,42 +1,41 @@
 // src/commands/rta_core/cache.rs
-//! Cache asynchrone pour les appels highdata (get_monster_duos)
-use crate::commands::rta_core::models::MonsterDuoStat;
-use crate::commands::rta_core::utils::get_monster_duos;
+//! Cache asynchrone pour les appels Lucksack (trios globaux ou par monstre)
+use crate::commands::rta_core::models::TrioStat;
+use crate::commands::rta_core::utils::{fetch_global_trios, fetch_monster_trios};
 use moka::future::Cache;
 use once_cell::sync::Lazy;
 use std::time::Duration;
 
-/// Clé : (monster_id, season, version, level)
-type DuoKey = (u32, i64, String, i32);
+/// Clé : (season, patch, rank, monster_id_or_0, min_games)
+type TrioKey = (i32, i32, i32, u32, u32);
 
-/// On stocke un Result<Vec<MonsterDuoStat>, String> pour propager l’erreur
-static DUO_CACHE: Lazy<Cache<DuoKey, Result<Vec<MonsterDuoStat>, String>>> = Lazy::new(|| {
+/// On stocke un Result<Vec<TrioStat>, String> pour propager l’erreur
+static TRIO_CACHE: Lazy<Cache<TrioKey, Result<Vec<TrioStat>, String>>> = Lazy::new(|| {
     Cache::builder()
-        .time_to_live(Duration::from_secs(96 * 3600))
-        .max_capacity(10_000)
+        .time_to_live(Duration::from_secs(6 * 3600))
+        .max_capacity(1_000)
         .build()
 });
 
-/// Wrapper : si absent ou expiré, appelle get_monster_duos et stocke le résultat
-pub async fn get_monster_duos_cached(
-    token: &str,
-    season: i64,
-    version: &str,
-    monster_id: u32,
-    level: i32,
-) -> Result<Vec<MonsterDuoStat>, String> {
-    let key = (monster_id, season, version.to_string(), level);
+/// Wrapper : si absent ou expiré, charge les trios (globaux ou par monstre) et stocke le résultat
+pub async fn get_trios_cached(
+    season: i32,
+    patch: i32,
+    rank: i32,
+    monster_id: Option<u32>,
+    min_games: u32,
+) -> Result<Vec<TrioStat>, String> {
+    let key = (season, patch, rank, monster_id.unwrap_or(0), min_games);
 
     // Loader qui renvoie un Result<…, String>
-    let loader = {
-        let token = token.to_string();
-        async move {
-            get_monster_duos(&token, season, version, monster_id, level)
-                .await
-                .map_err(|e| format!("Erreur highdata: {}", e))
+    let loader = async move {
+        if let Some(mid) = monster_id {
+            fetch_monster_trios(season, patch, rank, mid, min_games).await
+        } else {
+            fetch_global_trios(season, patch, rank, min_games).await
         }
     };
 
     // get_with charge si absent/expiré, et renvoie directement le Result
-    DUO_CACHE.get_with(key, loader).await
+    TRIO_CACHE.get_with(key, loader).await
 }

--- a/src/commands/rta_core/command.rs
+++ b/src/commands/rta_core/command.rs
@@ -1,26 +1,35 @@
+use crate::commands::how_to_build::utils::get_latest_lucksack_season;
 use crate::commands::mob_stats::command::autocomplete_monster;
-use crate::commands::mob_stats::utils::get_swrt_settings;
 use crate::commands::player_stats::utils::get_mob_emoji_collection;
-use crate::commands::rta_core::cache::get_monster_duos_cached;
-use crate::commands::rta_core::models::MonstersFile;
-use crate::commands::rta_core::models::{Mode, Rank, Trio};
+use crate::commands::rta_core::cache::get_trios_cached;
+use crate::commands::rta_core::models::{Rank, Sort, TrioStat};
 use crate::commands::rta_core::utils::{
-    filter_monster, get_emoji_from_id, get_monsters_from_json_bytes, get_swrt_version,
-    get_tierlist_data,
+    get_emoji_from_id, get_latest_patch, get_monsters_from_json_bytes,
 };
 use crate::commands::shared::embed_error_handling::{
     create_embed_error, schedule_message_deletion,
 };
 use crate::commands::shared::logs::{get_server_name, send_log};
 use crate::commands::shared::models::LoggerDocument;
-use crate::{Data, API_TOKEN};
-use poise::serenity_prelude::{Attachment, Error};
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::fs;
-
-// Import de la map globale
+use crate::Data;
 use crate::MONSTER_MAP;
+use poise::serenity_prelude::{Attachment, Error};
+use std::collections::HashSet;
+
+/// Envoie un embed d'erreur, planifie sa suppression et logge l'échec.
+async fn fail(ctx: poise::ApplicationContext<'_, Data, Error>, message: &str) -> Result<(), Error> {
+    let reply = ctx.send(create_embed_error(message)).await?;
+    schedule_message_deletion(reply, ctx).await?;
+    send_log(LoggerDocument::new(
+        &ctx.author().name,
+        "get_rta_core",
+        &get_server_name(&ctx).await?,
+        false,
+        chrono::Utc::now().timestamp(),
+    ))
+    .await?;
+    Ok(())
+}
 
 /// 📂 Displays best Trios to play for any given account JSON
 #[poise::command(slash_command)]
@@ -29,446 +38,220 @@ pub async fn get_rta_core(
     file: Attachment,
     #[description = "Select the targeted rank"] rank: Rank,
     #[autocomplete = "autocomplete_monster"]
-    #[description = "Monster you want to get core for (optional)"]
+    #[description = "Monster to focus the cores on (optional)"]
     monster: Option<String>,
-    #[description = "Mode of the core (Meta Slayer or Fun/Casual)"] mode: Mode,
+    #[autocomplete = "autocomplete_monster"]
+    #[description = "Monster to exclude from the trios (optional)"]
+    exclude: Option<String>,
+    #[description = "Sort order (optional; default: 5 most played + 5 best winrate)"] sort: Option<
+        Sort,
+    >,
+    #[description = "Minimum games per trio for reliability (optional, default 50)"]
+    min_games: Option<u32>,
 ) -> Result<(), Error> {
     // Évite le timeout de 3 s
     ctx.defer().await?;
 
-    let token = {
-        let guard = API_TOKEN.lock().unwrap();
-        guard.clone().ok_or_else(|| {
-            Error::from(std::io::Error::other(
-                "Missing API Token, please contact **b4tiste** on Discord : <https://discord.gg/AfANrTVaDJ>.",
-            ))
-        })?
-    };
-
     // Vérification présence de fichier
     if file.url.is_empty() {
-        let err = "No file provided. Please attach a JSON file.";
-        let reply = ctx.send(create_embed_error(err)).await?;
-        schedule_message_deletion(reply, ctx).await?;
-        send_log(LoggerDocument::new(
-            &ctx.author().name,
-            "get_rta_core",
-            &get_server_name(&ctx).await?,
-            false,
-            chrono::Utc::now().timestamp(),
-        ))
-        .await?;
-        return Ok(());
+        return fail(ctx, "No file provided. Please attach a JSON file.").await;
     }
 
     // Vérification extension
     if !file.filename.to_lowercase().ends_with(".json") {
-        let err = "The provided file is not a JSON file.";
-        let reply = ctx.send(create_embed_error(err)).await?;
-        schedule_message_deletion(reply, ctx).await?;
-        send_log(LoggerDocument::new(
-            &ctx.author().name,
-            "get_rta_core",
-            &get_server_name(&ctx).await?,
-            false,
-            chrono::Utc::now().timestamp(),
-        ))
-        .await?;
-        return Ok(());
+        return fail(ctx, "The provided file is not a JSON file.").await;
     }
 
     // Téléchargement
     let bytes = match file.download().await {
         Ok(b) => b,
         Err(e) => {
-            let err_msg = format!("Impossible de télécharger : {}", e);
-            let reply = ctx.send(create_embed_error(&err_msg)).await?;
-            schedule_message_deletion(reply, ctx).await?;
-            send_log(LoggerDocument::new(
-                &ctx.author().name,
-                "get_rta_core",
-                &get_server_name(&ctx).await?,
-                false,
-                chrono::Utc::now().timestamp(),
-            ))
-            .await?;
-            return Ok(());
+            return fail(ctx, &format!("Failed to download the file: {}", e)).await;
         }
     };
 
-    // 1️⃣ Charger le JSON statique "monsters_elements.json" pour connaître l'élément de chaque monstre
-    let monsters_json_str = fs::read_to_string("monsters_elements.json")
-        .expect("Impossible de lire monsters_elements.json");
-    let all_monsters_file: MonstersFile = serde_json::from_str(&monsters_json_str)
-        .expect("Impossible de parser monsters_elements.json");
+    // Extraction des monstres de la box
+    let monsters = match get_monsters_from_json_bytes(&bytes, "monsters_elements.json") {
+        Ok(m) => m,
+        Err(e) => {
+            return fail(ctx, &format!("Error: {}", e)).await;
+        }
+    };
+    let player_box_ids: HashSet<u32> = monsters.iter().map(|m| m.unit_master_id).collect();
 
-    // 2️⃣ Construire la table id → élément
-    let element_map: HashMap<u32, String> = all_monsters_file
-        .monsters
+    // Conversion du nom de monstre optionnel en ID
+    let filter_monster_id: Option<u32> = if let Some(ref name) = monster {
+        match MONSTER_MAP.get(name) {
+            Some(&id) => Some(id),
+            None => {
+                return fail(
+                    ctx,
+                    &format!(
+                        "Cannot find '{}', please use the autocomplete feature for a perfect match.",
+                        name
+                    ),
+                )
+                .await;
+            }
+        }
+    } else {
+        None
+    };
+
+    // Conversion du nom de monstre à exclure optionnel en ID
+    let exclude_id: Option<u32> = if let Some(ref name) = exclude {
+        match MONSTER_MAP.get(name) {
+            Some(&id) => Some(id),
+            None => {
+                return fail(
+                    ctx,
+                    &format!(
+                        "Cannot find '{}', please use the autocomplete feature for a perfect match.",
+                        name
+                    ),
+                )
+                .await;
+            }
+        }
+    } else {
+        None
+    };
+
+    let min_games_val = min_games.unwrap_or(50);
+
+    let season = match get_latest_lucksack_season().await {
+        Ok(s) => s,
+        Err(e) => {
+            return fail(ctx, &e).await;
+        }
+    };
+
+    let patch = match get_latest_patch(season).await {
+        Ok(p) => p,
+        Err(e) => {
+            return fail(ctx, &e).await;
+        }
+    };
+
+    let rank_val = rank.lucksack_rank();
+
+    let collection = match get_mob_emoji_collection().await {
+        Ok(c) => c,
+        Err(_) => {
+            return fail(ctx, "Database error while fetching emojis.").await;
+        }
+    };
+
+    let pool: Vec<TrioStat> =
+        match get_trios_cached(season, patch, rank_val, filter_monster_id, min_games_val).await {
+            Ok(p) => p,
+            Err(e) => {
+                return fail(ctx, &e).await;
+            }
+        };
+
+    // Filtre Box 3/3 : le trio entier doit être dans la box du joueur.
+    let playable: Vec<TrioStat> = pool
         .into_iter()
-        .map(|m| (m.com2us_id, m.element))
+        .filter(|t| t.ids.iter().all(|id| player_box_ids.contains(id)))
+        .filter(|t| exclude_id.is_none_or(|ex| !t.ids.contains(&ex)))
         .collect();
 
-    // Extraction des monsters
-    match get_monsters_from_json_bytes(&bytes, "monsters_elements.json") {
-        Ok(monsters) => {
-            // Si l'utilisateur a passé un nom de monstre, on le convertit en ID
-            let filter_monster_id: Option<u32> = if let Some(ref name) = monster {
-                match MONSTER_MAP.get(name) {
-                    Some(&id) => Some(id),
-                    None => {
-                        let msg = format!("❌ Cannot find '{}', please use the autocomplete feature for a perfect match.", name);
-                        let reply = ctx.send(create_embed_error(&msg)).await?;
-                        schedule_message_deletion(reply, ctx).await?;
-                        send_log(LoggerDocument::new(
-                            &ctx.author().name,
-                            "get_rta_core",
-                            &get_server_name(&ctx).await?,
-                            false,
-                            chrono::Utc::now().timestamp(),
-                        ))
-                        .await?;
-                        return Ok(());
-                    }
-                }
-            } else {
-                None
-            };
+    // Récupération du pseudo dans le fichier JSON uploadé (field wizard_info.wizard_name)
+    let json_str = String::from_utf8_lossy(&bytes).to_string();
+    let json_value: serde_json::Value = serde_json::from_str(&json_str).unwrap_or_default();
+    let wizard_name = json_value
+        .get("wizard_info")
+        .and_then(|w| w.get("wizard_name"))
+        .and_then(|w| w.as_str())
+        .unwrap_or("Unknown");
+    let wizard_name = if wizard_name.is_empty() {
+        "Unknown"
+    } else {
+        wizard_name
+    };
 
-            // 1) Déterminer le paramètre `level` SWRanking selon le Rank choisi
-            let api_level = match rank {
-                Rank::C1 | Rank::C2 | Rank::C3 | Rank::P1 | Rank::P2 => 0,
-                Rank::P3 | Rank::G1 | Rank::G2 => 1,
-                Rank::G3 => 3,
-            };
+    // En-tête
+    let mut msg = format!(
+        "🎯 Trios for `{}` to play in `{}`",
+        wizard_name,
+        rank.label()
+    );
+    if let Some(ref name) = monster {
+        msg.push_str(&format!(" focusing on `{}`", name));
+    }
+    if let Some(ref name) = exclude {
+        msg.push_str(&format!(" excluding `{}`", name));
+    }
+    msg.push_str(":\n");
 
-            let tierlist_data = match get_tierlist_data(api_level, &token).await {
-                Ok(data) => data,
-                Err(e) => {
-                    let err_msg = format!("Impossible de récupérer les données : {}", e);
-                    let reply = ctx.send(create_embed_error(&err_msg)).await?;
-                    schedule_message_deletion(reply, ctx).await?;
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                    return Ok(());
-                }
-            };
+    // Sections à afficher : (titre, clé de tri, nombre)
+    enum SortKey {
+        Count,
+        WinRate,
+    }
+    let sections: Vec<(&str, SortKey, usize)> = match sort {
+        None => vec![
+            ("Most Played", SortKey::Count, 5),
+            ("Best Winrate", SortKey::WinRate, 5),
+        ],
+        Some(Sort::MostPlayed) => vec![("Most Played", SortKey::Count, 10)],
+        Some(Sort::BestWinrate) => vec![("Best Winrate", SortKey::WinRate, 10)],
+    };
 
-            let mut late_pick_ratio_map = HashMap::new();
-            for m in tierlist_data
-                .sss_monster
-                .iter()
-                .chain(&tierlist_data.ss_monster)
-                .chain(&tierlist_data.s_monster)
-                .chain(&tierlist_data.a_monster)
-                .chain(&tierlist_data.b_monster)
-                .chain(&tierlist_data.c_monster)
-            {
-                let total = m.pick_total as f32;
-                let late_sum = (m.third_pick_total
-                    + m.fourth_pick_total
-                    + m.fifth_pick_total
-                    + m.last_pick_total) as f32;
-                let ratio = if total > 0.0 { late_sum / total } else { 0.0 };
-                late_pick_ratio_map.insert(m.monster_id, ratio);
-            }
+    for (title, key, count) in sections {
+        let title_line = match key {
+            SortKey::Count => format!("\n**🔥 {}**\n", title),
+            SortKey::WinRate => format!("\n**🏆 {}**\n", title),
+        };
+        msg.push_str(&title_line);
 
-            // Filtrage des monstres
-            let filtered_tierlist = filter_monster(&tierlist_data, &monsters);
+        let mut sorted = playable.clone();
+        match key {
+            SortKey::Count => sorted.sort_by_key(|t| std::cmp::Reverse(t.count)),
+            SortKey::WinRate => sorted.sort_by(|a, b| {
+                b.win_rate
+                    .partial_cmp(&a.win_rate)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }),
+        }
+        let top: Vec<TrioStat> = sorted.into_iter().take(count).collect();
 
-            // Récupération de la saison
-            let season = match get_swrt_settings(&token).await {
-                Ok(season) => season,
-                Err(e) => {
-                    let err = format!("Impossible de récupérer la saison : {}", e);
-                    ctx.send(create_embed_error(&err)).await.ok();
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                    0
-                }
-            };
-
-            // Récupération de la version SWRT
-            let version = match get_swrt_version(&token).await {
-                Ok(version) => version,
-                Err(e) => {
-                    let err = format!("Impossible de récupérer la version : {}", e);
-                    ctx.send(create_embed_error(&err)).await.ok();
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                    return Ok(());
-                }
-            };
-
-            // Préparation des IDs de monstres de la box
-            let player_box_ids: HashSet<u32> = monsters.iter().map(|m| m.unit_master_id).collect();
-            // Préparation des IDs core
-            let mut core_ids = std::collections::HashSet::new();
-            for m in &filtered_tierlist.sss_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.ss_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.s_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.a_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.b_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.c_monster {
-                core_ids.insert(m.monster_id);
-            }
-
-            // Collecte des trios
-            let mut seen_trios = HashSet::<(u32, u32, u32)>::new();
-            let mut trios: Vec<Trio> = Vec::new();
-
-            for base in filtered_tierlist
-                .sss_monster
-                .iter()
-                .chain(&filtered_tierlist.ss_monster)
-                .chain(&filtered_tierlist.s_monster)
-                .chain(&filtered_tierlist.a_monster)
-                .chain(&filtered_tierlist.b_monster)
-                .chain(&filtered_tierlist.c_monster)
-            {
-                let rank_duos = match rank {
-                    Rank::C1 | Rank::C2 | Rank::C3 => 0,
-                    Rank::P1 | Rank::P2 | Rank::P3 => 4,
-                    Rank::G1 | Rank::G2 => 1,
-                    Rank::G3 => 3,
-                };
-                if let Ok(duos) =
-                    get_monster_duos_cached(&token, season, &version, base.monster_id, rank_duos)
-                        .await
-                {
-                    for duo in duos {
-                        let (b, o, t) = (base.monster_id, duo.team_one_id, duo.team_two_id);
-
-                        // 👉 Si on a un filtre de monstre, on skip ceux qui ne le contiennent pas
-                        if let Some(filter_id) = filter_monster_id {
-                            if b != filter_id && o != filter_id && t != filter_id {
-                                continue;
-                            }
-                        }
-
-                        let mode_id = match mode {
-                            Mode::MetaSlayer => 0,
-                            Mode::FunAndCasual => 1,
-                        };
-
-                        if mode_id == 0 {
-                            // on ne garde que les trios 100% « core »
-                            if !core_ids.contains(&o) || !core_ids.contains(&t) {
-                                continue;
-                            }
-                        } else {
-                            // on ne garde que les trios où o et t sont dans la box du joueur
-                            if !player_box_ids.contains(&o) || !player_box_ids.contains(&t) {
-                                continue;
-                            }
-                        }
-
-                        // clé triée pour être indépendante de l’ordre
-                        let mut key = [b, o, t];
-                        key.sort_unstable();
-                        let key = (key[0], key[1], key[2]);
-                        // si on l’a déjà vu, on skip
-                        if !seen_trios.insert(key) {
-                            continue;
-                        }
-                        // sinon on calcule score et on push
-
-                        if let Ok(rate) = duo.win_rate.parse::<f32>() {
-                            let picks = duo.pick_total;
-                            // score de base
-                            let mut score = rate * (1.0 + (picks as f32).ln());
-
-                            // on calcule le late-pick ratio max sur les 3 membres
-                            let max_late = [b, o, t]
-                                .iter()
-                                .map(|id| *late_pick_ratio_map.get(id).unwrap_or(&0.0))
-                                .fold(0.0_f32, f32::max);
-
-                            // penalty = 1 − late_ratio : si late_ratio=1.0, tout est supprimé
-                            let penalty = 1.0 - max_late;
-                            score *= penalty;
-
-                            // Détection Light/Dark avec exclusions et boost variable
-                            let excluded_ids: HashSet<u32> =
-                                [21814, 28915, 19214, 19215].iter().cloned().collect();
-
-                            let light_dark_count = [b, o, t]
-                                .iter()
-                                .filter(|&&id| {
-                                    // on exclut d'abord certains IDs
-                                    !excluded_ids.contains(&id)
-                                    // puis on ne garde que Light ou Dark
-                                    && matches!(
-                                        element_map.get(&id).map(String::as_str),
-                                        Some("Light") | Some("Dark")
-                                    )
-                                })
-                                .count();
-
-                            // si on a au moins 1 monstre Light/Dark (hors exclusions), on calcule le boost
-                            if light_dark_count > 0 {
-                                let boost = match light_dark_count {
-                                    1 => 0.4,
-                                    2 => 0.6,
-                                    3 => 0.8,
-                                    _ => 0.0, // dans l'improbable cas de >3, pas de boost supplémentaire
-                                };
-                                score *= 1.0 + boost;
-                            }
-
-                            trios.push(Trio {
-                                base: b,
-                                one: o,
-                                two: t,
-                                win_rate: rate,
-                                pick_total: picks,
-                                weighted_score: score,
-                                emojis: None,
-                            });
-                        }
-                    }
-                } else {
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                }
-            }
-
-            // Tri et top
-            trios.sort_by(|a, b| b.weighted_score.partial_cmp(&a.weighted_score).unwrap());
-            let mut top = trios.into_iter().take(15).collect::<Vec<_>>();
-
-            // Récupération des emojis
-            let collection = get_mob_emoji_collection()
-                .await
-                .map_err(|_| Error::from(std::io::Error::other("DB error")))?;
-            for t in &mut top {
-                let emojis_string = format!(
+        if top.is_empty() {
+            msg.push_str("- No Trio Found\n");
+        } else {
+            for t in &top {
+                let emojis = format!(
                     "{} {} {}",
-                    get_emoji_from_id(&collection, t.base)
+                    get_emoji_from_id(&collection, t.ids[0])
                         .await
                         .unwrap_or_default(),
-                    get_emoji_from_id(&collection, t.one)
+                    get_emoji_from_id(&collection, t.ids[1])
                         .await
                         .unwrap_or_default(),
-                    get_emoji_from_id(&collection, t.two)
+                    get_emoji_from_id(&collection, t.ids[2])
                         .await
                         .unwrap_or_default()
                 );
-                t.emojis = Some(emojis_string);
+                msg.push_str(&format!(
+                    "- {} → **{:.1} %** WR ({})\n",
+                    emojis,
+                    t.win_rate * 100.0,
+                    t.count,
+                ));
             }
-
-            // Récupération en string du rank sélectionné
-            let rank_str = match rank {
-                Rank::C1 => "C1",
-                Rank::C2 => "C2",
-                Rank::C3 => "C3",
-                Rank::P1 => "P1",
-                Rank::P2 => "P2",
-                Rank::P3 => "P3",
-                Rank::G1 => "G1",
-                Rank::G2 => "G2",
-                Rank::G3 => "G3",
-            };
-
-            // Récupération du pseudo dans le fichier JSON uploadé (field wizard_info.wizard_name)
-            let json_str = String::from_utf8_lossy(&bytes).to_string();
-            let json_value: serde_json::Value = serde_json::from_str(&json_str).unwrap_or_default();
-            let wizard_name = json_value
-                .get("wizard_info")
-                .and_then(|w| w.get("wizard_name"))
-                .and_then(|w| w.as_str())
-                .unwrap_or("Unknown");
-            let wizard_name = if wizard_name.is_empty() {
-                "Unknown"
-            } else {
-                wizard_name
-            };
-
-            // Affichage final unique
-            let mode_str = match mode {
-                Mode::MetaSlayer => "Meta Slayer",
-                Mode::FunAndCasual => "Fun and Casual",
-            };
-            let mut msg = if let Some(ref name) = monster {
-                format!(
-                    "🎯 Trios for `{}` to play in `{}` (Mode `{}`) focusing on `{}`:\n",
-                    wizard_name, rank_str, mode_str, name
-                )
-            } else {
-                format!(
-                    "🎯 Trios for `{}` to play in `{}` (Mode `{}`):\n",
-                    wizard_name, rank_str, mode_str
-                )
-            };
-            if top.is_empty() {
-                msg.push_str("– No Trio Found\n");
-            } else {
-                for t in &top {
-                    msg.push_str(&format!(
-                        "- {} → **{:.1} %** WR ({})\n",
-                        t.emojis.clone().unwrap_or_default(),
-                        t.win_rate * 100.0,
-                        t.pick_total,
-                    ));
-                }
-            }
-            send_log(LoggerDocument::new(
-                &ctx.author().name,
-                "get_rta_core",
-                &get_server_name(&ctx).await?,
-                true,
-                chrono::Utc::now().timestamp(),
-            ))
-            .await?;
-            ctx.say(msg).await?;
-        }
-        Err(e) => {
-            let err_msg = format!("Erreur : {}", e);
-            let reply = ctx.send(create_embed_error(&err_msg)).await?;
-            schedule_message_deletion(reply, ctx).await?;
-            send_log(LoggerDocument::new(
-                &ctx.author().name,
-                "get_rta_core",
-                &get_server_name(&ctx).await?,
-                false,
-                chrono::Utc::now().timestamp(),
-            ))
-            .await?;
         }
     }
+
+    send_log(LoggerDocument::new(
+        &ctx.author().name,
+        "get_rta_core",
+        &get_server_name(&ctx).await?,
+        true,
+        chrono::Utc::now().timestamp(),
+    ))
+    .await?;
+    ctx.say(msg).await?;
+
     Ok(())
 }

--- a/src/commands/rta_core/dryrun.rs
+++ b/src/commands/rta_core/dryrun.rs
@@ -1,0 +1,154 @@
+//! Harnais console pour essayer /get_rta_core en local, sans Discord ni Mongo.
+//!
+//! Lancement :
+//!   RTA_CORE_TEST_JSON=/chemin/box.json cargo test rta_core_dryrun -- --nocapture
+//!
+//! Variables optionnelles :
+//!   RTA_CORE_TEST_RANK    = P1 | P2-P3 | G1-G3 | G3   (défaut : G1-G3)
+//!   RTA_CORE_TEST_MONSTER = nom exact d'un monstre     (active l'endpoint with-trio)
+//!   RTA_CORE_TEST_MIN     = seuil minimum de games     (défaut : 100)
+//!
+//! Sans RTA_CORE_TEST_JSON, le test est ignoré (aucun appel réseau).
+//! Réutilise le vrai code (parsing box, fetch Lucksack, filtre box, tri) ; les emojis
+//! Discord sont remplacés par les noms de monstres pour l'affichage console.
+
+use crate::commands::how_to_build::utils::get_latest_lucksack_season;
+use crate::commands::rta_core::cache::get_trios_cached;
+use crate::commands::rta_core::models::TrioStat;
+use crate::commands::rta_core::utils::{get_latest_patch, get_monsters_from_json_bytes};
+use crate::MONSTER_MAP;
+use std::collections::{HashMap, HashSet};
+
+fn rank_value(label: &str) -> i32 {
+    match label {
+        "P1" => 11,
+        "P2-P3" | "P2P3" => 103,
+        "G3" => 16,
+        _ => 102, // G1-G3 par défaut
+    }
+}
+
+fn print_section(title: &str, trios: &[TrioStat], id_to_name: &HashMap<u32, String>) {
+    println!("\n== {title} ==");
+    if trios.is_empty() {
+        println!("  (aucun trio)");
+        return;
+    }
+    let name = |id: u32| {
+        id_to_name
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(|| id.to_string())
+    };
+    for t in trios {
+        println!(
+            "  {} / {} / {}  ->  {:.1}% WR ({} games)",
+            name(t.ids[0]),
+            name(t.ids[1]),
+            name(t.ids[2]),
+            t.win_rate * 100.0,
+            t.count
+        );
+    }
+}
+
+#[tokio::test]
+async fn rta_core_dryrun() {
+    let json_path = match std::env::var("RTA_CORE_TEST_JSON") {
+        Ok(p) => p,
+        Err(_) => {
+            println!("RTA_CORE_TEST_JSON non défini : dry-run ignoré.");
+            return;
+        }
+    };
+
+    let rank_label = std::env::var("RTA_CORE_TEST_RANK").unwrap_or_else(|_| "G1-G3".to_string());
+    let rank = rank_value(&rank_label);
+    let min_games: u32 = std::env::var("RTA_CORE_TEST_MIN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+    let monster_name = std::env::var("RTA_CORE_TEST_MONSTER").ok();
+    let exclude_name = std::env::var("RTA_CORE_TEST_EXCLUDE").ok();
+
+    let bytes = std::fs::read(&json_path).expect("lecture du fichier RTA_CORE_TEST_JSON");
+
+    let monsters = get_monsters_from_json_bytes(&bytes, "monsters_elements.json")
+        .expect("parsing de la box / monsters_elements.json");
+    let player_box_ids: HashSet<u32> = monsters.iter().map(|m| m.unit_master_id).collect();
+
+    let id_to_name: HashMap<u32, String> = MONSTER_MAP
+        .iter()
+        .map(|(name, id)| (*id, name.clone()))
+        .collect();
+
+    let season = get_latest_lucksack_season()
+        .await
+        .expect("récupération de la saison");
+    let patch = get_latest_patch(season)
+        .await
+        .expect("récupération du patch");
+
+    let filter_id: Option<u32> = match &monster_name {
+        Some(n) => match MONSTER_MAP.get(n) {
+            Some(id) => Some(*id),
+            None => {
+                println!("Monstre '{n}' introuvable dans MONSTER_MAP (utilise le nom exact).");
+                return;
+            }
+        },
+        None => None,
+    };
+
+    let exclude_id: Option<u32> = match &exclude_name {
+        Some(n) => match MONSTER_MAP.get(n) {
+            Some(id) => Some(*id),
+            None => {
+                println!(
+                    "Monstre exclu '{n}' introuvable dans MONSTER_MAP (utilise le nom exact)."
+                );
+                return;
+            }
+        },
+        None => None,
+    };
+
+    println!(
+        "box={} monstres | season={season} patch={patch} rank={rank_label}({rank}) min_games={min_games}{}{}",
+        player_box_ids.len(),
+        monster_name
+            .as_ref()
+            .map(|n| format!(" | focus={n}"))
+            .unwrap_or_default(),
+        exclude_name
+            .as_ref()
+            .map(|n| format!(" | exclude={n}"))
+            .unwrap_or_default()
+    );
+
+    let pool: Vec<TrioStat> = get_trios_cached(season, patch, rank, filter_id, min_games)
+        .await
+        .expect("récupération des trios Lucksack");
+    println!("{} trios récupérés (avant filtre box)", pool.len());
+
+    let playable: Vec<TrioStat> = pool
+        .into_iter()
+        .filter(|t| t.ids.iter().all(|id| player_box_ids.contains(id)))
+        .filter(|t| exclude_id.is_none_or(|ex| !t.ids.contains(&ex)))
+        .collect();
+    println!("{} trios jouables (box 3/3)", playable.len());
+
+    let mut by_count = playable.clone();
+    by_count.sort_by_key(|t| std::cmp::Reverse(t.count));
+    let most_played: Vec<TrioStat> = by_count.into_iter().take(5).collect();
+    print_section("Most Played", &most_played, &id_to_name);
+
+    let mut by_wr = playable;
+    by_wr.sort_by(|a, b| {
+        b.win_rate
+            .partial_cmp(&a.win_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let best_wr: Vec<TrioStat> = by_wr.into_iter().take(5).collect();
+    print_section("Best Winrate", &best_wr, &id_to_name);
+}

--- a/src/commands/rta_core/mod.rs
+++ b/src/commands/rta_core/mod.rs
@@ -2,3 +2,6 @@ pub mod cache;
 pub mod command;
 pub mod models;
 pub mod utils;
+
+#[cfg(test)]
+mod dryrun;

--- a/src/commands/rta_core/models.rs
+++ b/src/commands/rta_core/models.rs
@@ -1,22 +1,43 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, poise::ChoiceParameter)]
-pub enum Mode {
-    MetaSlayer,
-    FunAndCasual,
+pub enum Rank {
+    #[name = "P1"]
+    P1,
+    #[name = "P2-P3"]
+    P2P3,
+    #[name = "G1-G3"]
+    G1G2G3,
+    #[name = "G3"]
+    G3,
+}
+
+impl Rank {
+    pub fn lucksack_rank(&self) -> i32 {
+        match self {
+            Rank::P1 => 11,
+            Rank::P2P3 => 103,
+            Rank::G1G2G3 => 102,
+            Rank::G3 => 16,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Rank::P1 => "P1",
+            Rank::P2P3 => "P2-P3",
+            Rank::G1G2G3 => "G1-G3",
+            Rank::G3 => "G3",
+        }
+    }
 }
 
 #[derive(Debug, poise::ChoiceParameter)]
-pub enum Rank {
-    C1,
-    C2,
-    C3,
-    P1,
-    P2,
-    P3,
-    G1,
-    G2,
-    G3,
+pub enum Sort {
+    #[name = "Most Played"]
+    MostPlayed,
+    #[name = "Best Winrate"]
+    BestWinrate,
 }
 
 /// Représente une entrée brute du fichier monsters.json
@@ -82,32 +103,50 @@ pub struct MonsterStat {
     pub last_pick_total: u32,
 }
 
-/// Représente une entrée de la réponse highdata (duo pour un monstre de base)
-#[derive(Deserialize, Clone)]
-pub struct MonsterDuoStat {
-    #[serde(rename = "teamMonsterOneId")]
-    pub team_one_id: u32,
-    // #[serde(rename = "teamOneImgFilename")]
-    // pub team_one_img: String,
-    #[serde(rename = "teamMonsterTwoId")]
-    pub team_two_id: u32,
-    // #[serde(rename = "teamTwoImgFilename")]
-    // pub team_two_img: String,
-    // #[serde(rename = "winTotal")]
-    // pub win_total: u32,
-    #[serde(rename = "pickTotal")]
-    pub pick_total: u32,
-    #[serde(rename = "winRate")]
-    pub win_rate: String,
+/// Modèle local normalisé pour un trio
+#[derive(Clone)]
+pub struct TrioStat {
+    pub ids: [u32; 3],
+    pub count: u32,
+    pub win_rate: f32,
 }
 
-/// Modèle local pour un trio, avec métrique pondérée
-pub struct Trio {
-    pub base: u32,
-    pub one: u32,
-    pub two: u32,
-    pub win_rate: f32,          // ex. 0.55
-    pub pick_total: u32,        // ex. 1432
-    pub weighted_score: f32,    // win_rate * pick_total
-    pub emojis: Option<String>, // emojis
+/// Réponse statistics/trio
+#[derive(Deserialize, Clone)]
+pub struct LucksackTrioResponse {
+    pub records: Vec<LucksackTrioRecord>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct LucksackTrioRecord {
+    pub monster_id: Vec<u32>,
+    pub played_count: u32,
+    pub win_rate: f32,
+}
+
+/// Réponse monsters/{id}/with-trio
+#[derive(Deserialize, Clone)]
+pub struct LucksackWithTrioResponse {
+    pub records: Vec<LucksackWithTrioRecord>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct LucksackWithTrioRecord {
+    pub units1: LucksackUnitRef,
+    pub units2: LucksackUnitRef,
+    pub units3: LucksackUnitRef,
+    pub appearances: u32,
+    pub winrate: f32,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct LucksackUnitRef {
+    pub monster_id: u32,
+}
+
+/// Réponse patches
+#[derive(Deserialize, Clone)]
+pub struct LucksackPatch {
+    pub patch_id: i32,
+    pub patch_order: i32,
 }

--- a/src/commands/rta_core/utils.rs
+++ b/src/commands/rta_core/utils.rs
@@ -1,7 +1,9 @@
 use crate::commands::mob_stats::utils::remap_monster_id;
 use crate::commands::rta_core::models::{
-    Monster, MonsterDuoStat, MonsterEntry, MonstersFile, TierListData,
+    LucksackPatch, LucksackTrioRecord, LucksackTrioResponse, LucksackWithTrioResponse, Monster,
+    MonsterEntry, MonstersFile, TierListData, TrioStat,
 };
+use crate::commands::shared::clients::http_client;
 use anyhow::{Context, Result};
 use chrono::NaiveDate;
 use mongodb::{bson::doc, Collection};
@@ -9,6 +11,9 @@ use reqwest::Client;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::fs;
+
+/// Nombre maximal de pages (100 trios chacune) récupérées par appel Lucksack.
+const MAX_TRIO_PAGES: i32 = 15;
 
 /// Lit le JSON dynamique (upload), extrait les unit_master_id,
 /// puis charge monsters.json et renvoie les Monster correspondants.
@@ -121,94 +126,155 @@ pub async fn get_tierlist_data(api_level: i32, token: &str) -> Result<TierListDa
     Ok(tierlist_data)
 }
 
-pub async fn get_swrt_version(token: &str) -> Result<String, String> {
-    let url = "https://m.swranking.com/api/setting/settingMap";
+/// Récupère le dernier patch d'une saison Lucksack (celui avec le patch_order maximal).
+pub async fn get_latest_patch(season: i32) -> Result<i32, String> {
+    let url = format!("https://api.lucksack.gg/seasons/{}/patches", season);
 
-    let client = Client::new();
-    let response = client
-        .get(url)
-        .header("Authentication", token)
-        .header("Referer", "https://m.swranking.com/")
-        .header("User-Agent", "Mozilla/5.0")
-        .send()
-        .await
-        .map_err(|_| "Failed get settings".to_string())?;
-
-    let json = response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(|_| "Failed to parse settings JSON".to_string())?;
-
-    let version_str = json["data"]["nowVersion"]
-        .as_str()
-        .ok_or("Missing nowVersion".to_string())?;
-
-    Ok(version_str.to_string())
-}
-
-/// Récupère les duos (highOneWithTwoList) pour un monstre donné
-pub async fn get_monster_duos(
-    token: &str,
-    season: i64,
-    version: &str,
-    monster_id: u32,
-    level: i32,
-) -> Result<Vec<MonsterDuoStat>> {
-    let url = format!(
-        "https://m.swranking.com/api/monster/highdata?pageNum=1&pageSize=20&monsterId={}&season={}&version={}&level={}&factor=0.01&real=0",
-        monster_id, season, version, level
-    );
-    let client = Client::new();
-    let resp = client
+    let res = http_client()
         .get(&url)
-        .header("Authentication", token)
-        .header("Referer", "https://m.swranking.com/")
-        .header("User-Agent", "Mozilla/5.0")
+        .header("user-agent", "Mozilla/5.0 (X11; Linux x86_64)")
+        .header("sec-fetch-site", "none")
         .send()
-        .await?
-        .json::<Value>()
-        .await?;
-    let list = resp["data"]["highOneWithTwoList"]
-        .as_array()
-        .context("Missing highOneWithTwoList")?;
-    let duos = serde_json::from_value(Value::Array(list.clone()))?;
-    Ok(duos)
+        .await
+        .map_err(|_| "Failed to send request".to_string())?;
+
+    if !res.status().is_success() {
+        return Err(format!("HTTP {}", res.status()));
+    }
+
+    let patches = res
+        .json::<Vec<LucksackPatch>>()
+        .await
+        .map_err(|_| "Failed to parse patches JSON".to_string())?;
+
+    patches
+        .into_iter()
+        .max_by_key(|p| p.patch_order)
+        .map(|p| p.patch_id)
+        .ok_or_else(|| "No patch found".to_string())
 }
 
-pub fn filter_monster(tierlist_data: &TierListData, monsters: &[Monster]) -> TierListData {
-    let mut filtered_tierlist = tierlist_data.clone();
-    filtered_tierlist.sss_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.ss_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.s_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.a_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.b_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.c_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
+/// Récupère les trios globaux d'un rank pour une saison/patch, filtrés localement
+/// par min_games (statistics/trio ne supporte pas min_appearances).
+pub async fn fetch_global_trios(
+    season: i32,
+    patch: i32,
+    rank: i32,
+    min_games: u32,
+) -> Result<Vec<TrioStat>, String> {
+    let mut result: Vec<TrioStat> = Vec::new();
 
-    filtered_tierlist
+    for page in 0..MAX_TRIO_PAGES {
+        let offset = page * 100;
+        let url = format!(
+            "https://api.lucksack.gg/statistics/trio?season={}&rank={}&patch={}&limit=100&offset={}&order_by=Pick&order_direction=Desc",
+            season, rank, patch, offset
+        );
+
+        let res = http_client()
+            .get(&url)
+            .header("user-agent", "Mozilla/5.0 (X11; Linux x86_64)")
+            .header("sec-fetch-site", "none")
+            .send()
+            .await
+            .map_err(|_| "Failed to send request".to_string())?;
+
+        if !res.status().is_success() {
+            return Err(format!("HTTP {}", res.status()));
+        }
+
+        let body = res
+            .json::<LucksackTrioResponse>()
+            .await
+            .map_err(|_| "Failed to parse trio JSON".to_string())?;
+
+        let page_len = body.records.len();
+
+        for record in body.records {
+            let LucksackTrioRecord {
+                monster_id,
+                played_count,
+                win_rate,
+            } = record;
+
+            if monster_id.len() != 3 {
+                continue;
+            }
+
+            if played_count < min_games {
+                continue;
+            }
+
+            result.push(TrioStat {
+                ids: [monster_id[0], monster_id[1], monster_id[2]],
+                count: played_count,
+                win_rate,
+            });
+        }
+
+        if page_len < 100 {
+            break;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Récupère les trios contenant un monstre donné. min_games est appliqué côté serveur
+/// via min_appearances.
+pub async fn fetch_monster_trios(
+    season: i32,
+    patch: i32,
+    rank: i32,
+    monster_id: u32,
+    min_games: u32,
+) -> Result<Vec<TrioStat>, String> {
+    let mut result: Vec<TrioStat> = Vec::new();
+
+    for page in 0..MAX_TRIO_PAGES {
+        let offset = page * 100;
+        let url = format!(
+            "https://api.lucksack.gg/monsters/{}/with-trio?season={}&rank={}&patch={}&limit=100&offset={}&order_by=appearances&order_direction=desc&min_appearances={}",
+            monster_id, season, rank, patch, offset, min_games
+        );
+
+        let res = http_client()
+            .get(&url)
+            .header("user-agent", "Mozilla/5.0 (X11; Linux x86_64)")
+            .header("sec-fetch-site", "none")
+            .send()
+            .await
+            .map_err(|_| "Failed to send request".to_string())?;
+
+        if !res.status().is_success() {
+            return Err(format!("HTTP {}", res.status()));
+        }
+
+        let body = res
+            .json::<LucksackWithTrioResponse>()
+            .await
+            .map_err(|_| "Failed to parse with-trio JSON".to_string())?;
+
+        let page_len = body.records.len();
+
+        for record in body.records {
+            result.push(TrioStat {
+                ids: [
+                    record.units1.monster_id,
+                    record.units2.monster_id,
+                    record.units3.monster_id,
+                ],
+                count: record.appearances,
+                win_rate: record.winrate,
+            });
+        }
+
+        if page_len < 100 {
+            break;
+        }
+    }
+
+    Ok(result)
 }
 
 pub async fn get_emoji_from_id(


### PR DESCRIPTION
## Résumé

Migre la commande `/get_rta_core` de SWRT vers l'API publique Lucksack (sans token).

## Changements

- **Source de données** : remplace les endpoints méta SWRT (tier-list + duos `highdata`, authentifiés par token) par les statistiques de trios Lucksack :
  - `statistics/trio` pour le pool global, `monsters/{id}/with-trio` quand un monstre est ciblé ;
  - résolution dynamique de la saison et du dernier patch.
- **Rangs** : réduits aux 4 brackets Lucksack (`P1`, `P2-P3`, `G1-G3`, `G3`). Les rangs Conqueror et les modes `Meta Slayer` / `Fun & Casual` sont retirés.
- **Nouveaux paramètres optionnels** : `monster` (focus sur un monstre), `exclude` (exclusion d'un monstre), `sort` (`Most Played` / `Best Winrate`, défaut : 5 de chaque), `min_games` (défaut : 50).
- **Comportement** : seuls les trios entièrement présents dans la box uploadée sont affichés (sections Most Played / Best Winrate). Pagination jusqu'à 1500 trios, cache 6 h.
- `/meta` reste intact (réutilise toujours `get_tierlist_data`, `MonsterStat` et `get_emoji_from_id`).
- README mis à jour pour la nouvelle interface de la commande.

## Vérification

`cargo fmt --check`, `cargo build` et `cargo clippy --all-targets --all-features -- -D warnings` passent. Testé end-to-end sur des données réelles via un harnais console (`dryrun.rs`, `#[cfg(test)]`, déclenché par variable d'environnement, sans impact sur le CI).
