### PR TITLE
feat: interactive /get_rta_core with rank buttons and trio companions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,18 @@ Supported modes:
 - `Anonymized`
 - `NoSpeedDetailAndAnonymized`
 
-### `/get_rta_core <file> <rank> [monster] <mode>`
+### `/get_rta_core <file> <rank> [monster] [exclude] [sort] [min_games]`
 
-Computes top trios from your box and current meta data.
+Computes the best trios you can field from your account box, using live trio statistics from Lucksack for the selected rank and current patch. Only trios whose three monsters are all in your box are shown.
 
 Supported rank values:
-- `C1`, `C2`, `C3`, `P1`, `P2`, `P3`, `G1`, `G2`, `G3`
+- `P1`, `P2-P3`, `G1-G3`, `G3`
 
-Supported mode values:
-- `MetaSlayer`
-- `FunAndCasual`
+Optional parameters:
+- `monster`: focus on trios containing this monster (uses Lucksack's per-monster trios).
+- `exclude`: hide trios containing this monster.
+- `sort`: `Most Played` or `Best Winrate` (default: 5 of each).
+- `min_games`: minimum games per trio for reliability (default: 50).
 
 ### `/track_player_names <mode>`
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Supported modes:
 
 Computes the best trios you can field from your account box, using live trio statistics from Lucksack for the selected rank and current patch. Only trios whose three monsters are all in your box are shown.
 
+The reply is an interactive embed:
+- **Rank buttons** (P1 / P2-P3 / G1-G3 / G3) switch the bracket without re-uploading the file.
+- **Trio select menu**: pick a displayed trio to reveal its most frequent 4th/5th companions (popularity stars + winrate), each flagged ✅ if you own it or ❌ if it is missing from your box.
+
 Supported rank values:
 - `P1`, `P2-P3`, `G1-G3`, `G3`
 

--- a/src/commands/rta_core/cache.rs
+++ b/src/commands/rta_core/cache.rs
@@ -1,42 +1,41 @@
 // src/commands/rta_core/cache.rs
-//! Cache asynchrone pour les appels highdata (get_monster_duos)
-use crate::commands::rta_core::models::MonsterDuoStat;
-use crate::commands::rta_core::utils::get_monster_duos;
+//! Cache asynchrone pour les appels Lucksack (trios globaux ou par monstre)
+use crate::commands::rta_core::models::TrioStat;
+use crate::commands::rta_core::utils::{fetch_global_trios, fetch_monster_trios};
 use moka::future::Cache;
 use once_cell::sync::Lazy;
 use std::time::Duration;
 
-/// Clé : (monster_id, season, version, level)
-type DuoKey = (u32, i64, String, i32);
+/// Clé : (season, patch, rank, monster_id_or_0, min_games)
+type TrioKey = (i32, i32, i32, u32, u32);
 
-/// On stocke un Result<Vec<MonsterDuoStat>, String> pour propager l’erreur
-static DUO_CACHE: Lazy<Cache<DuoKey, Result<Vec<MonsterDuoStat>, String>>> = Lazy::new(|| {
+/// On stocke un Result<Vec<TrioStat>, String> pour propager l’erreur
+static TRIO_CACHE: Lazy<Cache<TrioKey, Result<Vec<TrioStat>, String>>> = Lazy::new(|| {
     Cache::builder()
-        .time_to_live(Duration::from_secs(96 * 3600))
-        .max_capacity(10_000)
+        .time_to_live(Duration::from_secs(6 * 3600))
+        .max_capacity(1_000)
         .build()
 });
 
-/// Wrapper : si absent ou expiré, appelle get_monster_duos et stocke le résultat
-pub async fn get_monster_duos_cached(
-    token: &str,
-    season: i64,
-    version: &str,
-    monster_id: u32,
-    level: i32,
-) -> Result<Vec<MonsterDuoStat>, String> {
-    let key = (monster_id, season, version.to_string(), level);
+/// Wrapper : si absent ou expiré, charge les trios (globaux ou par monstre) et stocke le résultat
+pub async fn get_trios_cached(
+    season: i32,
+    patch: i32,
+    rank: i32,
+    monster_id: Option<u32>,
+    min_games: u32,
+) -> Result<Vec<TrioStat>, String> {
+    let key = (season, patch, rank, monster_id.unwrap_or(0), min_games);
 
     // Loader qui renvoie un Result<…, String>
-    let loader = {
-        let token = token.to_string();
-        async move {
-            get_monster_duos(&token, season, version, monster_id, level)
-                .await
-                .map_err(|e| format!("Erreur highdata: {}", e))
+    let loader = async move {
+        if let Some(mid) = monster_id {
+            fetch_monster_trios(season, patch, rank, mid, min_games).await
+        } else {
+            fetch_global_trios(season, patch, rank, min_games).await
         }
     };
 
     // get_with charge si absent/expiré, et renvoie directement le Result
-    DUO_CACHE.get_with(key, loader).await
+    TRIO_CACHE.get_with(key, loader).await
 }

--- a/src/commands/rta_core/command.rs
+++ b/src/commands/rta_core/command.rs
@@ -1,10 +1,13 @@
-use crate::commands::how_to_build::utils::get_latest_lucksack_season;
+use crate::commands::how_to_build::utils::{
+    create_lucksack_rank_buttons, get_latest_lucksack_season,
+};
 use crate::commands::mob_stats::command::autocomplete_monster;
 use crate::commands::player_stats::utils::get_mob_emoji_collection;
 use crate::commands::rta_core::cache::get_trios_cached;
 use crate::commands::rta_core::models::{Rank, Sort, TrioStat};
 use crate::commands::rta_core::utils::{
-    get_emoji_from_id, get_latest_patch, get_monsters_from_json_bytes,
+    build_rta_core_embed, build_sections, build_trio_select_menu, derive_companions,
+    get_latest_patch, get_monsters_from_json_bytes, load_all_mob_emojis,
 };
 use crate::commands::shared::embed_error_handling::{
     create_embed_error, schedule_message_deletion,
@@ -13,8 +16,48 @@ use crate::commands::shared::logs::{get_server_name, send_log};
 use crate::commands::shared::models::LoggerDocument;
 use crate::Data;
 use crate::MONSTER_MAP;
-use poise::serenity_prelude::{Attachment, Error};
-use std::collections::HashSet;
+use poise::serenity_prelude::builder::EditInteractionResponse;
+use poise::serenity_prelude::{
+    self as serenity, Attachment, ComponentInteractionDataKind, CreateInteractionResponse,
+    CreateInteractionResponseMessage, Error,
+};
+use poise::CreateReply;
+use std::collections::{HashMap, HashSet};
+
+/// Nombre maximal de compagnons (4e/5e picks) affichés pour un trio.
+const MAX_COMPANIONS: usize = 4;
+
+/// Libellé d'un rang Lucksack pour l'affichage (le bouton courant peut différer du param initial).
+fn rank_label_for(rank: i32) -> &'static str {
+    match rank {
+        11 => "P1",
+        103 => "P2-P3",
+        102 => "G1-G3",
+        16 => "G3",
+        _ => "?",
+    }
+}
+
+/// Filtre Box 3/3 : le trio entier doit être dans la box, hors monstre exclu.
+fn compute_playable(
+    pool: &[TrioStat],
+    box_ids: &HashSet<u32>,
+    exclude_id: Option<u32>,
+) -> Vec<TrioStat> {
+    pool.iter()
+        .filter(|t| t.ids.iter().all(|id| box_ids.contains(id)))
+        .filter(|t| exclude_id.is_none_or(|ex| !t.ids.contains(&ex)))
+        .cloned()
+        .collect()
+}
+
+/// Trios affichés (union dédupliquée des sections), pour alimenter le menu de sélection.
+fn flatten_sections(sections: &[(&'static str, &'static str, Vec<TrioStat>)]) -> Vec<TrioStat> {
+    sections
+        .iter()
+        .flat_map(|(_, _, v)| v.iter().cloned())
+        .collect()
+}
 
 /// Envoie un embed d'erreur, planifie sa suppression et logge l'échec.
 async fn fail(ctx: poise::ApplicationContext<'_, Data, Error>, message: &str) -> Result<(), Error> {
@@ -133,113 +176,230 @@ pub async fn get_rta_core(
         }
     };
 
-    let rank_val = rank.lucksack_rank();
+    let mut current_rank = rank.lucksack_rank();
 
+    // Collection emojis chargée une seule fois (re-rendus interactifs rapides).
     let collection = match get_mob_emoji_collection().await {
         Ok(c) => c,
         Err(_) => {
             return fail(ctx, "Database error while fetching emojis.").await;
         }
     };
+    let emoji_map = load_all_mob_emojis(&collection).await;
 
-    let pool: Vec<TrioStat> =
-        match get_trios_cached(season, patch, rank_val, filter_monster_id, min_games_val).await {
-            Ok(p) => p,
-            Err(e) => {
-                return fail(ctx, &e).await;
-            }
-        };
-
-    // Filtre Box 3/3 : le trio entier doit être dans la box du joueur.
-    let playable: Vec<TrioStat> = pool
-        .into_iter()
-        .filter(|t| t.ids.iter().all(|id| player_box_ids.contains(id)))
-        .filter(|t| exclude_id.is_none_or(|ex| !t.ids.contains(&ex)))
+    // id -> nom (depuis MONSTER_MAP) pour les libellés du menu et les fallbacks.
+    let id_to_name: HashMap<u32, String> = MONSTER_MAP
+        .iter()
+        .map(|(name, id)| (*id, name.clone()))
         .collect();
 
-    // Récupération du pseudo dans le fichier JSON uploadé (field wizard_info.wizard_name)
+    // Pseudo depuis le fichier JSON uploadé (field wizard_info.wizard_name)
     let json_str = String::from_utf8_lossy(&bytes).to_string();
     let json_value: serde_json::Value = serde_json::from_str(&json_str).unwrap_or_default();
     let wizard_name = json_value
         .get("wizard_info")
         .and_then(|w| w.get("wizard_name"))
         .and_then(|w| w.as_str())
-        .unwrap_or("Unknown");
-    let wizard_name = if wizard_name.is_empty() {
-        "Unknown"
-    } else {
-        wizard_name
-    };
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Unknown")
+        .to_string();
 
-    // En-tête
-    let mut msg = format!(
-        "🎯 Trios for `{}` to play in `{}`",
-        wizard_name,
-        rank.label()
-    );
-    if let Some(ref name) = monster {
-        msg.push_str(&format!(" focusing on `{}`", name));
-    }
-    if let Some(ref name) = exclude {
-        msg.push_str(&format!(" excluding `{}`", name));
-    }
-    msg.push_str(":\n");
-
-    // Sections à afficher : (titre, clé de tri, nombre)
-    enum SortKey {
-        Count,
-        WinRate,
-    }
-    let sections: Vec<(&str, SortKey, usize)> = match sort {
-        None => vec![
-            ("Most Played", SortKey::Count, 5),
-            ("Best Winrate", SortKey::WinRate, 5),
-        ],
-        Some(Sort::MostPlayed) => vec![("Most Played", SortKey::Count, 10)],
-        Some(Sort::BestWinrate) => vec![("Best Winrate", SortKey::WinRate, 10)],
-    };
-
-    for (title, key, count) in sections {
-        let title_line = match key {
-            SortKey::Count => format!("\n**🔥 {}**\n", title),
-            SortKey::WinRate => format!("\n**🏆 {}**\n", title),
-        };
-        msg.push_str(&title_line);
-
-        let mut sorted = playable.clone();
-        match key {
-            SortKey::Count => sorted.sort_by_key(|t| std::cmp::Reverse(t.count)),
-            SortKey::WinRate => sorted.sort_by(|a, b| {
-                b.win_rate
-                    .partial_cmp(&a.win_rate)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            }),
+    // Récupération initiale du pool + dérivation de la vue.
+    let mut pool = match get_trios_cached(
+        season,
+        patch,
+        current_rank,
+        filter_monster_id,
+        min_games_val,
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            return fail(ctx, &e).await;
         }
-        let top: Vec<TrioStat> = sorted.into_iter().take(count).collect();
+    };
+    let mut playable = compute_playable(&pool, &player_box_ids, exclude_id);
+    let mut sections = build_sections(&playable, sort.as_ref());
+    let mut displayed = flatten_sections(&sections);
 
-        if top.is_empty() {
-            msg.push_str("- No Trio Found\n");
-        } else {
-            for t in &top {
-                let emojis = format!(
-                    "{} {} {}",
-                    get_emoji_from_id(&collection, t.ids[0])
-                        .await
-                        .unwrap_or_default(),
-                    get_emoji_from_id(&collection, t.ids[1])
-                        .await
-                        .unwrap_or_default(),
-                    get_emoji_from_id(&collection, t.ids[2])
-                        .await
-                        .unwrap_or_default()
+    let embed = build_rta_core_embed(
+        &wizard_name,
+        rank_label_for(current_rank),
+        monster.as_deref(),
+        exclude.as_deref(),
+        playable.len(),
+        &sections,
+        &emoji_map,
+        &id_to_name,
+        &player_box_ids,
+        None,
+    );
+    let mut components = vec![create_lucksack_rank_buttons(current_rank, false)];
+    if let Some(menu) = build_trio_select_menu(&displayed, &emoji_map, &id_to_name) {
+        components.push(menu);
+    }
+
+    let reply = ctx
+        .send(CreateReply {
+            embeds: vec![embed],
+            components: Some(components),
+            ..Default::default()
+        })
+        .await?;
+
+    let message_id = reply.message().await?.id;
+    let channel_id = ctx.channel_id();
+    let user_id = ctx.author().id;
+
+    while let Some(interaction) =
+        serenity::ComponentInteractionCollector::new(&ctx.serenity_context.shard)
+            .channel_id(channel_id)
+            .message_id(message_id)
+            .filter(move |i| i.user.id == user_id)
+            .timeout(std::time::Duration::from_secs(600))
+            .await
+    {
+        match interaction.data.custom_id.as_str() {
+            "rank_p1" | "rank_p2p3" | "rank_g1g2g3" | "rank_g3" => {
+                let new_rank = match interaction.data.custom_id.as_str() {
+                    "rank_g3" => 16,
+                    "rank_g1g2g3" => 102,
+                    "rank_p2p3" => 103,
+                    "rank_p1" => 11,
+                    _ => current_rank,
+                };
+
+                if new_rank == current_rank {
+                    interaction
+                        .create_response(
+                            &ctx.serenity_context,
+                            CreateInteractionResponse::Acknowledge,
+                        )
+                        .await?;
+                    continue;
+                }
+                current_rank = new_rank;
+
+                interaction
+                    .create_response(
+                        &ctx.serenity_context,
+                        CreateInteractionResponse::UpdateMessage(
+                            CreateInteractionResponseMessage::new()
+                                .content("🔄 Loading...")
+                                .components(vec![create_lucksack_rank_buttons(current_rank, true)]),
+                        ),
+                    )
+                    .await?;
+
+                pool = match get_trios_cached(
+                    season,
+                    patch,
+                    current_rank,
+                    filter_monster_id,
+                    min_games_val,
+                )
+                .await
+                {
+                    Ok(p) => p,
+                    Err(e) => {
+                        interaction
+                            .edit_response(
+                                &ctx.serenity_context.http,
+                                EditInteractionResponse::new()
+                                    .content(format!("❌ {}", e))
+                                    .embeds(vec![])
+                                    .components(vec![create_lucksack_rank_buttons(
+                                        current_rank,
+                                        false,
+                                    )]),
+                            )
+                            .await?;
+                        continue;
+                    }
+                };
+                playable = compute_playable(&pool, &player_box_ids, exclude_id);
+                sections = build_sections(&playable, sort.as_ref());
+                displayed = flatten_sections(&sections);
+
+                let embed = build_rta_core_embed(
+                    &wizard_name,
+                    rank_label_for(current_rank),
+                    monster.as_deref(),
+                    exclude.as_deref(),
+                    playable.len(),
+                    &sections,
+                    &emoji_map,
+                    &id_to_name,
+                    &player_box_ids,
+                    None,
                 );
-                msg.push_str(&format!(
-                    "- {} → **{:.1} %** WR ({})\n",
-                    emojis,
-                    t.win_rate * 100.0,
-                    t.count,
-                ));
+                let mut components = vec![create_lucksack_rank_buttons(current_rank, false)];
+                if let Some(menu) = build_trio_select_menu(&displayed, &emoji_map, &id_to_name) {
+                    components.push(menu);
+                }
+                interaction
+                    .edit_response(
+                        &ctx.serenity_context.http,
+                        EditInteractionResponse::new()
+                            .content("")
+                            .embeds(vec![embed])
+                            .components(components),
+                    )
+                    .await?;
             }
+            "rta_core_trio_select" => {
+                let value = match &interaction.data.kind {
+                    ComponentInteractionDataKind::StringSelect { values } => {
+                        values.first().cloned()
+                    }
+                    _ => None,
+                };
+                let ids: Vec<u32> = value
+                    .as_deref()
+                    .map(|v| v.split('_').filter_map(|s| s.parse().ok()).collect())
+                    .unwrap_or_default();
+                if ids.len() != 3 {
+                    interaction
+                        .create_response(
+                            &ctx.serenity_context,
+                            CreateInteractionResponse::Acknowledge,
+                        )
+                        .await?;
+                    continue;
+                }
+                let trio = [ids[0], ids[1], ids[2]];
+                let companions = derive_companions(&pool, trio, exclude_id, MAX_COMPANIONS);
+                let selected = (trio, companions);
+
+                let embed = build_rta_core_embed(
+                    &wizard_name,
+                    rank_label_for(current_rank),
+                    monster.as_deref(),
+                    exclude.as_deref(),
+                    playable.len(),
+                    &sections,
+                    &emoji_map,
+                    &id_to_name,
+                    &player_box_ids,
+                    Some(&selected),
+                );
+                let mut components = vec![create_lucksack_rank_buttons(current_rank, false)];
+                if let Some(menu) = build_trio_select_menu(&displayed, &emoji_map, &id_to_name) {
+                    components.push(menu);
+                }
+                interaction
+                    .create_response(
+                        &ctx.serenity_context,
+                        CreateInteractionResponse::UpdateMessage(
+                            CreateInteractionResponseMessage::new()
+                                .embeds(vec![embed])
+                                .components(components),
+                        ),
+                    )
+                    .await?;
+            }
+            _ => continue,
         }
     }
 
@@ -251,7 +411,6 @@ pub async fn get_rta_core(
         chrono::Utc::now().timestamp(),
     ))
     .await?;
-    ctx.say(msg).await?;
 
     Ok(())
 }

--- a/src/commands/rta_core/command.rs
+++ b/src/commands/rta_core/command.rs
@@ -1,26 +1,35 @@
+use crate::commands::how_to_build::utils::get_latest_lucksack_season;
 use crate::commands::mob_stats::command::autocomplete_monster;
-use crate::commands::mob_stats::utils::get_swrt_settings;
 use crate::commands::player_stats::utils::get_mob_emoji_collection;
-use crate::commands::rta_core::cache::get_monster_duos_cached;
-use crate::commands::rta_core::models::MonstersFile;
-use crate::commands::rta_core::models::{Mode, Rank, Trio};
+use crate::commands::rta_core::cache::get_trios_cached;
+use crate::commands::rta_core::models::{Rank, Sort, TrioStat};
 use crate::commands::rta_core::utils::{
-    filter_monster, get_emoji_from_id, get_monsters_from_json_bytes, get_swrt_version,
-    get_tierlist_data,
+    get_emoji_from_id, get_latest_patch, get_monsters_from_json_bytes,
 };
 use crate::commands::shared::embed_error_handling::{
     create_embed_error, schedule_message_deletion,
 };
 use crate::commands::shared::logs::{get_server_name, send_log};
 use crate::commands::shared::models::LoggerDocument;
-use crate::{Data, API_TOKEN};
-use poise::serenity_prelude::{Attachment, Error};
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::fs;
-
-// Import de la map globale
+use crate::Data;
 use crate::MONSTER_MAP;
+use poise::serenity_prelude::{Attachment, Error};
+use std::collections::HashSet;
+
+/// Envoie un embed d'erreur, planifie sa suppression et logge l'échec.
+async fn fail(ctx: poise::ApplicationContext<'_, Data, Error>, message: &str) -> Result<(), Error> {
+    let reply = ctx.send(create_embed_error(message)).await?;
+    schedule_message_deletion(reply, ctx).await?;
+    send_log(LoggerDocument::new(
+        &ctx.author().name,
+        "get_rta_core",
+        &get_server_name(&ctx).await?,
+        false,
+        chrono::Utc::now().timestamp(),
+    ))
+    .await?;
+    Ok(())
+}
 
 /// 📂 Displays best Trios to play for any given account JSON
 #[poise::command(slash_command)]
@@ -29,446 +38,220 @@ pub async fn get_rta_core(
     file: Attachment,
     #[description = "Select the targeted rank"] rank: Rank,
     #[autocomplete = "autocomplete_monster"]
-    #[description = "Monster you want to get core for (optional)"]
+    #[description = "Monster to focus the cores on (optional)"]
     monster: Option<String>,
-    #[description = "Mode of the core (Meta Slayer or Fun/Casual)"] mode: Mode,
+    #[autocomplete = "autocomplete_monster"]
+    #[description = "Monster to exclude from the trios (optional)"]
+    exclude: Option<String>,
+    #[description = "Sort order (optional; default: 5 most played + 5 best winrate)"] sort: Option<
+        Sort,
+    >,
+    #[description = "Minimum games per trio for reliability (optional, default 50)"]
+    min_games: Option<u32>,
 ) -> Result<(), Error> {
     // Évite le timeout de 3 s
     ctx.defer().await?;
 
-    let token = {
-        let guard = API_TOKEN.lock().unwrap();
-        guard.clone().ok_or_else(|| {
-            Error::from(std::io::Error::other(
-                "Missing API Token, please contact **b4tiste** on Discord : <https://discord.gg/AfANrTVaDJ>.",
-            ))
-        })?
-    };
-
     // Vérification présence de fichier
     if file.url.is_empty() {
-        let err = "No file provided. Please attach a JSON file.";
-        let reply = ctx.send(create_embed_error(err)).await?;
-        schedule_message_deletion(reply, ctx).await?;
-        send_log(LoggerDocument::new(
-            &ctx.author().name,
-            "get_rta_core",
-            &get_server_name(&ctx).await?,
-            false,
-            chrono::Utc::now().timestamp(),
-        ))
-        .await?;
-        return Ok(());
+        return fail(ctx, "No file provided. Please attach a JSON file.").await;
     }
 
     // Vérification extension
     if !file.filename.to_lowercase().ends_with(".json") {
-        let err = "The provided file is not a JSON file.";
-        let reply = ctx.send(create_embed_error(err)).await?;
-        schedule_message_deletion(reply, ctx).await?;
-        send_log(LoggerDocument::new(
-            &ctx.author().name,
-            "get_rta_core",
-            &get_server_name(&ctx).await?,
-            false,
-            chrono::Utc::now().timestamp(),
-        ))
-        .await?;
-        return Ok(());
+        return fail(ctx, "The provided file is not a JSON file.").await;
     }
 
     // Téléchargement
     let bytes = match file.download().await {
         Ok(b) => b,
         Err(e) => {
-            let err_msg = format!("Impossible de télécharger : {}", e);
-            let reply = ctx.send(create_embed_error(&err_msg)).await?;
-            schedule_message_deletion(reply, ctx).await?;
-            send_log(LoggerDocument::new(
-                &ctx.author().name,
-                "get_rta_core",
-                &get_server_name(&ctx).await?,
-                false,
-                chrono::Utc::now().timestamp(),
-            ))
-            .await?;
-            return Ok(());
+            return fail(ctx, &format!("Failed to download the file: {}", e)).await;
         }
     };
 
-    // 1️⃣ Charger le JSON statique "monsters_elements.json" pour connaître l'élément de chaque monstre
-    let monsters_json_str = fs::read_to_string("monsters_elements.json")
-        .expect("Impossible de lire monsters_elements.json");
-    let all_monsters_file: MonstersFile = serde_json::from_str(&monsters_json_str)
-        .expect("Impossible de parser monsters_elements.json");
+    // Extraction des monstres de la box
+    let monsters = match get_monsters_from_json_bytes(&bytes, "monsters_elements.json") {
+        Ok(m) => m,
+        Err(e) => {
+            return fail(ctx, &format!("Error: {}", e)).await;
+        }
+    };
+    let player_box_ids: HashSet<u32> = monsters.iter().map(|m| m.unit_master_id).collect();
 
-    // 2️⃣ Construire la table id → élément
-    let element_map: HashMap<u32, String> = all_monsters_file
-        .monsters
+    // Conversion du nom de monstre optionnel en ID
+    let filter_monster_id: Option<u32> = if let Some(ref name) = monster {
+        match MONSTER_MAP.get(name) {
+            Some(&id) => Some(id),
+            None => {
+                return fail(
+                    ctx,
+                    &format!(
+                        "Cannot find '{}', please use the autocomplete feature for a perfect match.",
+                        name
+                    ),
+                )
+                .await;
+            }
+        }
+    } else {
+        None
+    };
+
+    // Conversion du nom de monstre à exclure optionnel en ID
+    let exclude_id: Option<u32> = if let Some(ref name) = exclude {
+        match MONSTER_MAP.get(name) {
+            Some(&id) => Some(id),
+            None => {
+                return fail(
+                    ctx,
+                    &format!(
+                        "Cannot find '{}', please use the autocomplete feature for a perfect match.",
+                        name
+                    ),
+                )
+                .await;
+            }
+        }
+    } else {
+        None
+    };
+
+    let min_games_val = min_games.unwrap_or(50);
+
+    let season = match get_latest_lucksack_season().await {
+        Ok(s) => s,
+        Err(e) => {
+            return fail(ctx, &e).await;
+        }
+    };
+
+    let patch = match get_latest_patch(season).await {
+        Ok(p) => p,
+        Err(e) => {
+            return fail(ctx, &e).await;
+        }
+    };
+
+    let rank_val = rank.lucksack_rank();
+
+    let collection = match get_mob_emoji_collection().await {
+        Ok(c) => c,
+        Err(_) => {
+            return fail(ctx, "Database error while fetching emojis.").await;
+        }
+    };
+
+    let pool: Vec<TrioStat> =
+        match get_trios_cached(season, patch, rank_val, filter_monster_id, min_games_val).await {
+            Ok(p) => p,
+            Err(e) => {
+                return fail(ctx, &e).await;
+            }
+        };
+
+    // Filtre Box 3/3 : le trio entier doit être dans la box du joueur.
+    let playable: Vec<TrioStat> = pool
         .into_iter()
-        .map(|m| (m.com2us_id, m.element))
+        .filter(|t| t.ids.iter().all(|id| player_box_ids.contains(id)))
+        .filter(|t| exclude_id.is_none_or(|ex| !t.ids.contains(&ex)))
         .collect();
 
-    // Extraction des monsters
-    match get_monsters_from_json_bytes(&bytes, "monsters_elements.json") {
-        Ok(monsters) => {
-            // Si l'utilisateur a passé un nom de monstre, on le convertit en ID
-            let filter_monster_id: Option<u32> = if let Some(ref name) = monster {
-                match MONSTER_MAP.get(name) {
-                    Some(&id) => Some(id),
-                    None => {
-                        let msg = format!("❌ Cannot find '{}', please use the autocomplete feature for a perfect match.", name);
-                        let reply = ctx.send(create_embed_error(&msg)).await?;
-                        schedule_message_deletion(reply, ctx).await?;
-                        send_log(LoggerDocument::new(
-                            &ctx.author().name,
-                            "get_rta_core",
-                            &get_server_name(&ctx).await?,
-                            false,
-                            chrono::Utc::now().timestamp(),
-                        ))
-                        .await?;
-                        return Ok(());
-                    }
-                }
-            } else {
-                None
-            };
+    // Récupération du pseudo dans le fichier JSON uploadé (field wizard_info.wizard_name)
+    let json_str = String::from_utf8_lossy(&bytes).to_string();
+    let json_value: serde_json::Value = serde_json::from_str(&json_str).unwrap_or_default();
+    let wizard_name = json_value
+        .get("wizard_info")
+        .and_then(|w| w.get("wizard_name"))
+        .and_then(|w| w.as_str())
+        .unwrap_or("Unknown");
+    let wizard_name = if wizard_name.is_empty() {
+        "Unknown"
+    } else {
+        wizard_name
+    };
 
-            // 1) Déterminer le paramètre `level` SWRanking selon le Rank choisi
-            let api_level = match rank {
-                Rank::C1 | Rank::C2 | Rank::C3 | Rank::P1 | Rank::P2 => 0,
-                Rank::P3 | Rank::G1 | Rank::G2 => 1,
-                Rank::G3 => 3,
-            };
+    // En-tête
+    let mut msg = format!(
+        "🎯 Trios for `{}` to play in `{}`",
+        wizard_name,
+        rank.label()
+    );
+    if let Some(ref name) = monster {
+        msg.push_str(&format!(" focusing on `{}`", name));
+    }
+    if let Some(ref name) = exclude {
+        msg.push_str(&format!(" excluding `{}`", name));
+    }
+    msg.push_str(":\n");
 
-            let tierlist_data = match get_tierlist_data(api_level, &token).await {
-                Ok(data) => data,
-                Err(e) => {
-                    let err_msg = format!("Impossible de récupérer les données : {}", e);
-                    let reply = ctx.send(create_embed_error(&err_msg)).await?;
-                    schedule_message_deletion(reply, ctx).await?;
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                    return Ok(());
-                }
-            };
+    // Sections à afficher : (titre, clé de tri, nombre)
+    enum SortKey {
+        Count,
+        WinRate,
+    }
+    let sections: Vec<(&str, SortKey, usize)> = match sort {
+        None => vec![
+            ("Most Played", SortKey::Count, 5),
+            ("Best Winrate", SortKey::WinRate, 5),
+        ],
+        Some(Sort::MostPlayed) => vec![("Most Played", SortKey::Count, 10)],
+        Some(Sort::BestWinrate) => vec![("Best Winrate", SortKey::WinRate, 10)],
+    };
 
-            let mut late_pick_ratio_map = HashMap::new();
-            for m in tierlist_data
-                .sss_monster
-                .iter()
-                .chain(&tierlist_data.ss_monster)
-                .chain(&tierlist_data.s_monster)
-                .chain(&tierlist_data.a_monster)
-                .chain(&tierlist_data.b_monster)
-                .chain(&tierlist_data.c_monster)
-            {
-                let total = m.pick_total as f32;
-                let late_sum = (m.third_pick_total
-                    + m.fourth_pick_total
-                    + m.fifth_pick_total
-                    + m.last_pick_total) as f32;
-                let ratio = if total > 0.0 { late_sum / total } else { 0.0 };
-                late_pick_ratio_map.insert(m.monster_id, ratio);
-            }
+    for (title, key, count) in sections {
+        let title_line = match key {
+            SortKey::Count => format!("\n**🔥 {}**\n", title),
+            SortKey::WinRate => format!("\n**🏆 {}**\n", title),
+        };
+        msg.push_str(&title_line);
 
-            // Filtrage des monstres
-            let filtered_tierlist = filter_monster(&tierlist_data, &monsters);
+        let mut sorted = playable.clone();
+        match key {
+            SortKey::Count => sorted.sort_by_key(|t| std::cmp::Reverse(t.count)),
+            SortKey::WinRate => sorted.sort_by(|a, b| {
+                b.win_rate
+                    .partial_cmp(&a.win_rate)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }),
+        }
+        let top: Vec<TrioStat> = sorted.into_iter().take(count).collect();
 
-            // Récupération de la saison
-            let season = match get_swrt_settings(&token).await {
-                Ok(season) => season,
-                Err(e) => {
-                    let err = format!("Impossible de récupérer la saison : {}", e);
-                    ctx.send(create_embed_error(&err)).await.ok();
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                    0
-                }
-            };
-
-            // Récupération de la version SWRT
-            let version = match get_swrt_version(&token).await {
-                Ok(version) => version,
-                Err(e) => {
-                    let err = format!("Impossible de récupérer la version : {}", e);
-                    ctx.send(create_embed_error(&err)).await.ok();
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                    return Ok(());
-                }
-            };
-
-            // Préparation des IDs de monstres de la box
-            let player_box_ids: HashSet<u32> = monsters.iter().map(|m| m.unit_master_id).collect();
-            // Préparation des IDs core
-            let mut core_ids = std::collections::HashSet::new();
-            for m in &filtered_tierlist.sss_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.ss_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.s_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.a_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.b_monster {
-                core_ids.insert(m.monster_id);
-            }
-            for m in &filtered_tierlist.c_monster {
-                core_ids.insert(m.monster_id);
-            }
-
-            // Collecte des trios
-            let mut seen_trios = HashSet::<(u32, u32, u32)>::new();
-            let mut trios: Vec<Trio> = Vec::new();
-
-            for base in filtered_tierlist
-                .sss_monster
-                .iter()
-                .chain(&filtered_tierlist.ss_monster)
-                .chain(&filtered_tierlist.s_monster)
-                .chain(&filtered_tierlist.a_monster)
-                .chain(&filtered_tierlist.b_monster)
-                .chain(&filtered_tierlist.c_monster)
-            {
-                let rank_duos = match rank {
-                    Rank::C1 | Rank::C2 | Rank::C3 => 0,
-                    Rank::P1 | Rank::P2 | Rank::P3 => 4,
-                    Rank::G1 | Rank::G2 => 1,
-                    Rank::G3 => 3,
-                };
-                if let Ok(duos) =
-                    get_monster_duos_cached(&token, season, &version, base.monster_id, rank_duos)
-                        .await
-                {
-                    for duo in duos {
-                        let (b, o, t) = (base.monster_id, duo.team_one_id, duo.team_two_id);
-
-                        // 👉 Si on a un filtre de monstre, on skip ceux qui ne le contiennent pas
-                        if let Some(filter_id) = filter_monster_id {
-                            if b != filter_id && o != filter_id && t != filter_id {
-                                continue;
-                            }
-                        }
-
-                        let mode_id = match mode {
-                            Mode::MetaSlayer => 0,
-                            Mode::FunAndCasual => 1,
-                        };
-
-                        if mode_id == 0 {
-                            // on ne garde que les trios 100% « core »
-                            if !core_ids.contains(&o) || !core_ids.contains(&t) {
-                                continue;
-                            }
-                        } else {
-                            // on ne garde que les trios où o et t sont dans la box du joueur
-                            if !player_box_ids.contains(&o) || !player_box_ids.contains(&t) {
-                                continue;
-                            }
-                        }
-
-                        // clé triée pour être indépendante de l’ordre
-                        let mut key = [b, o, t];
-                        key.sort_unstable();
-                        let key = (key[0], key[1], key[2]);
-                        // si on l’a déjà vu, on skip
-                        if !seen_trios.insert(key) {
-                            continue;
-                        }
-                        // sinon on calcule score et on push
-
-                        if let Ok(rate) = duo.win_rate.parse::<f32>() {
-                            let picks = duo.pick_total;
-                            // score de base
-                            let mut score = rate * (1.0 + (picks as f32).ln());
-
-                            // on calcule le late-pick ratio max sur les 3 membres
-                            let max_late = [b, o, t]
-                                .iter()
-                                .map(|id| *late_pick_ratio_map.get(id).unwrap_or(&0.0))
-                                .fold(0.0_f32, f32::max);
-
-                            // penalty = 1 − late_ratio : si late_ratio=1.0, tout est supprimé
-                            let penalty = 1.0 - max_late;
-                            score *= penalty;
-
-                            // Détection Light/Dark avec exclusions et boost variable
-                            let excluded_ids: HashSet<u32> =
-                                [21814, 28915, 19214, 19215].iter().cloned().collect();
-
-                            let light_dark_count = [b, o, t]
-                                .iter()
-                                .filter(|&&id| {
-                                    // on exclut d'abord certains IDs
-                                    !excluded_ids.contains(&id)
-                                    // puis on ne garde que Light ou Dark
-                                    && matches!(
-                                        element_map.get(&id).map(String::as_str),
-                                        Some("Light") | Some("Dark")
-                                    )
-                                })
-                                .count();
-
-                            // si on a au moins 1 monstre Light/Dark (hors exclusions), on calcule le boost
-                            if light_dark_count > 0 {
-                                let boost = match light_dark_count {
-                                    1 => 0.4,
-                                    2 => 0.6,
-                                    3 => 0.8,
-                                    _ => 0.0, // dans l'improbable cas de >3, pas de boost supplémentaire
-                                };
-                                score *= 1.0 + boost;
-                            }
-
-                            trios.push(Trio {
-                                base: b,
-                                one: o,
-                                two: t,
-                                win_rate: rate,
-                                pick_total: picks,
-                                weighted_score: score,
-                                emojis: None,
-                            });
-                        }
-                    }
-                } else {
-                    send_log(LoggerDocument::new(
-                        &ctx.author().name,
-                        "get_rta_core",
-                        &get_server_name(&ctx).await?,
-                        false,
-                        chrono::Utc::now().timestamp(),
-                    ))
-                    .await?;
-                }
-            }
-
-            // Tri et top
-            trios.sort_by(|a, b| b.weighted_score.partial_cmp(&a.weighted_score).unwrap());
-            let mut top = trios.into_iter().take(15).collect::<Vec<_>>();
-
-            // Récupération des emojis
-            let collection = get_mob_emoji_collection()
-                .await
-                .map_err(|_| Error::from(std::io::Error::other("DB error")))?;
-            for t in &mut top {
-                let emojis_string = format!(
+        if top.is_empty() {
+            msg.push_str("- No Trio Found\n");
+        } else {
+            for t in &top {
+                let emojis = format!(
                     "{} {} {}",
-                    get_emoji_from_id(&collection, t.base)
+                    get_emoji_from_id(&collection, t.ids[0])
                         .await
                         .unwrap_or_default(),
-                    get_emoji_from_id(&collection, t.one)
+                    get_emoji_from_id(&collection, t.ids[1])
                         .await
                         .unwrap_or_default(),
-                    get_emoji_from_id(&collection, t.two)
+                    get_emoji_from_id(&collection, t.ids[2])
                         .await
                         .unwrap_or_default()
                 );
-                t.emojis = Some(emojis_string);
+                msg.push_str(&format!(
+                    "- {} → **{:.1} %** WR ({})\n",
+                    emojis,
+                    t.win_rate * 100.0,
+                    t.count,
+                ));
             }
-
-            // Récupération en string du rank sélectionné
-            let rank_str = match rank {
-                Rank::C1 => "C1",
-                Rank::C2 => "C2",
-                Rank::C3 => "C3",
-                Rank::P1 => "P1",
-                Rank::P2 => "P2",
-                Rank::P3 => "P3",
-                Rank::G1 => "G1",
-                Rank::G2 => "G2",
-                Rank::G3 => "G3",
-            };
-
-            // Récupération du pseudo dans le fichier JSON uploadé (field wizard_info.wizard_name)
-            let json_str = String::from_utf8_lossy(&bytes).to_string();
-            let json_value: serde_json::Value = serde_json::from_str(&json_str).unwrap_or_default();
-            let wizard_name = json_value
-                .get("wizard_info")
-                .and_then(|w| w.get("wizard_name"))
-                .and_then(|w| w.as_str())
-                .unwrap_or("Unknown");
-            let wizard_name = if wizard_name.is_empty() {
-                "Unknown"
-            } else {
-                wizard_name
-            };
-
-            // Affichage final unique
-            let mode_str = match mode {
-                Mode::MetaSlayer => "Meta Slayer",
-                Mode::FunAndCasual => "Fun and Casual",
-            };
-            let mut msg = if let Some(ref name) = monster {
-                format!(
-                    "🎯 Trios for `{}` to play in `{}` (Mode `{}`) focusing on `{}`:\n",
-                    wizard_name, rank_str, mode_str, name
-                )
-            } else {
-                format!(
-                    "🎯 Trios for `{}` to play in `{}` (Mode `{}`):\n",
-                    wizard_name, rank_str, mode_str
-                )
-            };
-            if top.is_empty() {
-                msg.push_str("– No Trio Found\n");
-            } else {
-                for t in &top {
-                    msg.push_str(&format!(
-                        "- {} → **{:.1} %** WR ({})\n",
-                        t.emojis.clone().unwrap_or_default(),
-                        t.win_rate * 100.0,
-                        t.pick_total,
-                    ));
-                }
-            }
-            send_log(LoggerDocument::new(
-                &ctx.author().name,
-                "get_rta_core",
-                &get_server_name(&ctx).await?,
-                true,
-                chrono::Utc::now().timestamp(),
-            ))
-            .await?;
-            ctx.say(msg).await?;
-        }
-        Err(e) => {
-            let err_msg = format!("Erreur : {}", e);
-            let reply = ctx.send(create_embed_error(&err_msg)).await?;
-            schedule_message_deletion(reply, ctx).await?;
-            send_log(LoggerDocument::new(
-                &ctx.author().name,
-                "get_rta_core",
-                &get_server_name(&ctx).await?,
-                false,
-                chrono::Utc::now().timestamp(),
-            ))
-            .await?;
         }
     }
+
+    send_log(LoggerDocument::new(
+        &ctx.author().name,
+        "get_rta_core",
+        &get_server_name(&ctx).await?,
+        true,
+        chrono::Utc::now().timestamp(),
+    ))
+    .await?;
+    ctx.say(msg).await?;
+
     Ok(())
 }

--- a/src/commands/rta_core/dryrun.rs
+++ b/src/commands/rta_core/dryrun.rs
@@ -14,8 +14,10 @@
 
 use crate::commands::how_to_build::utils::get_latest_lucksack_season;
 use crate::commands::rta_core::cache::get_trios_cached;
-use crate::commands::rta_core::models::TrioStat;
-use crate::commands::rta_core::utils::{get_latest_patch, get_monsters_from_json_bytes};
+use crate::commands::rta_core::models::{Companion, TrioStat};
+use crate::commands::rta_core::utils::{
+    derive_companions, get_latest_patch, get_monsters_from_json_bytes,
+};
 use crate::MONSTER_MAP;
 use std::collections::{HashMap, HashSet};
 
@@ -132,9 +134,10 @@ async fn rta_core_dryrun() {
     println!("{} trios récupérés (avant filtre box)", pool.len());
 
     let playable: Vec<TrioStat> = pool
-        .into_iter()
+        .iter()
         .filter(|t| t.ids.iter().all(|id| player_box_ids.contains(id)))
         .filter(|t| exclude_id.is_none_or(|ex| !t.ids.contains(&ex)))
+        .cloned()
         .collect();
     println!("{} trios jouables (box 3/3)", playable.len());
 
@@ -151,4 +154,55 @@ async fn rta_core_dryrun() {
     });
     let best_wr: Vec<TrioStat> = by_wr.into_iter().take(5).collect();
     print_section("Best Winrate", &best_wr, &id_to_name);
+
+    // Compagnons (4e/5e picks) dérivés du pool brut pour le trio le plus joué.
+    if let Some(top) = most_played.first() {
+        let companions = derive_companions(&pool, top.ids, exclude_id, 4);
+        print_companions(top, &companions, &player_box_ids, &id_to_name);
+    }
+}
+
+fn print_companions(
+    trio: &TrioStat,
+    companions: &[Companion],
+    box_ids: &HashSet<u32>,
+    id_to_name: &HashMap<u32, String>,
+) {
+    let name = |id: u32| {
+        id_to_name
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(|| id.to_string())
+    };
+    println!(
+        "\n== Companions for {} / {} / {} ==",
+        name(trio.ids[0]),
+        name(trio.ids[1]),
+        name(trio.ids[2])
+    );
+    if companions.is_empty() {
+        println!("  (aucun compagnon fiable)");
+        return;
+    }
+    let max_count = companions.iter().map(|c| c.count).max().unwrap_or(0);
+    for c in companions {
+        let badge = if box_ids.contains(&c.id) {
+            "OWNED"
+        } else {
+            "MISSING"
+        };
+        let ratio = if max_count > 0 {
+            c.count as f32 / max_count as f32
+        } else {
+            0.0
+        };
+        println!(
+            "  {} [{}]  pop {:.0}% · {:.0}% WR ({} co-occ.)",
+            name(c.id),
+            badge,
+            ratio * 100.0,
+            c.win_rate * 100.0,
+            c.count
+        );
+    }
 }

--- a/src/commands/rta_core/dryrun.rs
+++ b/src/commands/rta_core/dryrun.rs
@@ -1,0 +1,154 @@
+//! Harnais console pour essayer /get_rta_core en local, sans Discord ni Mongo.
+//!
+//! Lancement :
+//!   RTA_CORE_TEST_JSON=/chemin/box.json cargo test rta_core_dryrun -- --nocapture
+//!
+//! Variables optionnelles :
+//!   RTA_CORE_TEST_RANK    = P1 | P2-P3 | G1-G3 | G3   (défaut : G1-G3)
+//!   RTA_CORE_TEST_MONSTER = nom exact d'un monstre     (active l'endpoint with-trio)
+//!   RTA_CORE_TEST_MIN     = seuil minimum de games     (défaut : 100)
+//!
+//! Sans RTA_CORE_TEST_JSON, le test est ignoré (aucun appel réseau).
+//! Réutilise le vrai code (parsing box, fetch Lucksack, filtre box, tri) ; les emojis
+//! Discord sont remplacés par les noms de monstres pour l'affichage console.
+
+use crate::commands::how_to_build::utils::get_latest_lucksack_season;
+use crate::commands::rta_core::cache::get_trios_cached;
+use crate::commands::rta_core::models::TrioStat;
+use crate::commands::rta_core::utils::{get_latest_patch, get_monsters_from_json_bytes};
+use crate::MONSTER_MAP;
+use std::collections::{HashMap, HashSet};
+
+fn rank_value(label: &str) -> i32 {
+    match label {
+        "P1" => 11,
+        "P2-P3" | "P2P3" => 103,
+        "G3" => 16,
+        _ => 102, // G1-G3 par défaut
+    }
+}
+
+fn print_section(title: &str, trios: &[TrioStat], id_to_name: &HashMap<u32, String>) {
+    println!("\n== {title} ==");
+    if trios.is_empty() {
+        println!("  (aucun trio)");
+        return;
+    }
+    let name = |id: u32| {
+        id_to_name
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(|| id.to_string())
+    };
+    for t in trios {
+        println!(
+            "  {} / {} / {}  ->  {:.1}% WR ({} games)",
+            name(t.ids[0]),
+            name(t.ids[1]),
+            name(t.ids[2]),
+            t.win_rate * 100.0,
+            t.count
+        );
+    }
+}
+
+#[tokio::test]
+async fn rta_core_dryrun() {
+    let json_path = match std::env::var("RTA_CORE_TEST_JSON") {
+        Ok(p) => p,
+        Err(_) => {
+            println!("RTA_CORE_TEST_JSON non défini : dry-run ignoré.");
+            return;
+        }
+    };
+
+    let rank_label = std::env::var("RTA_CORE_TEST_RANK").unwrap_or_else(|_| "G1-G3".to_string());
+    let rank = rank_value(&rank_label);
+    let min_games: u32 = std::env::var("RTA_CORE_TEST_MIN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+    let monster_name = std::env::var("RTA_CORE_TEST_MONSTER").ok();
+    let exclude_name = std::env::var("RTA_CORE_TEST_EXCLUDE").ok();
+
+    let bytes = std::fs::read(&json_path).expect("lecture du fichier RTA_CORE_TEST_JSON");
+
+    let monsters = get_monsters_from_json_bytes(&bytes, "monsters_elements.json")
+        .expect("parsing de la box / monsters_elements.json");
+    let player_box_ids: HashSet<u32> = monsters.iter().map(|m| m.unit_master_id).collect();
+
+    let id_to_name: HashMap<u32, String> = MONSTER_MAP
+        .iter()
+        .map(|(name, id)| (*id, name.clone()))
+        .collect();
+
+    let season = get_latest_lucksack_season()
+        .await
+        .expect("récupération de la saison");
+    let patch = get_latest_patch(season)
+        .await
+        .expect("récupération du patch");
+
+    let filter_id: Option<u32> = match &monster_name {
+        Some(n) => match MONSTER_MAP.get(n) {
+            Some(id) => Some(*id),
+            None => {
+                println!("Monstre '{n}' introuvable dans MONSTER_MAP (utilise le nom exact).");
+                return;
+            }
+        },
+        None => None,
+    };
+
+    let exclude_id: Option<u32> = match &exclude_name {
+        Some(n) => match MONSTER_MAP.get(n) {
+            Some(id) => Some(*id),
+            None => {
+                println!(
+                    "Monstre exclu '{n}' introuvable dans MONSTER_MAP (utilise le nom exact)."
+                );
+                return;
+            }
+        },
+        None => None,
+    };
+
+    println!(
+        "box={} monstres | season={season} patch={patch} rank={rank_label}({rank}) min_games={min_games}{}{}",
+        player_box_ids.len(),
+        monster_name
+            .as_ref()
+            .map(|n| format!(" | focus={n}"))
+            .unwrap_or_default(),
+        exclude_name
+            .as_ref()
+            .map(|n| format!(" | exclude={n}"))
+            .unwrap_or_default()
+    );
+
+    let pool: Vec<TrioStat> = get_trios_cached(season, patch, rank, filter_id, min_games)
+        .await
+        .expect("récupération des trios Lucksack");
+    println!("{} trios récupérés (avant filtre box)", pool.len());
+
+    let playable: Vec<TrioStat> = pool
+        .into_iter()
+        .filter(|t| t.ids.iter().all(|id| player_box_ids.contains(id)))
+        .filter(|t| exclude_id.is_none_or(|ex| !t.ids.contains(&ex)))
+        .collect();
+    println!("{} trios jouables (box 3/3)", playable.len());
+
+    let mut by_count = playable.clone();
+    by_count.sort_by_key(|t| std::cmp::Reverse(t.count));
+    let most_played: Vec<TrioStat> = by_count.into_iter().take(5).collect();
+    print_section("Most Played", &most_played, &id_to_name);
+
+    let mut by_wr = playable;
+    by_wr.sort_by(|a, b| {
+        b.win_rate
+            .partial_cmp(&a.win_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let best_wr: Vec<TrioStat> = by_wr.into_iter().take(5).collect();
+    print_section("Best Winrate", &best_wr, &id_to_name);
+}

--- a/src/commands/rta_core/mod.rs
+++ b/src/commands/rta_core/mod.rs
@@ -2,3 +2,6 @@ pub mod cache;
 pub mod command;
 pub mod models;
 pub mod utils;
+
+#[cfg(test)]
+mod dryrun;

--- a/src/commands/rta_core/models.rs
+++ b/src/commands/rta_core/models.rs
@@ -21,15 +21,6 @@ impl Rank {
             Rank::G3 => 16,
         }
     }
-
-    pub fn label(&self) -> &'static str {
-        match self {
-            Rank::P1 => "P1",
-            Rank::P2P3 => "P2-P3",
-            Rank::G1G2G3 => "G1-G3",
-            Rank::G3 => "G3",
-        }
-    }
 }
 
 #[derive(Debug, poise::ChoiceParameter)]
@@ -107,6 +98,15 @@ pub struct MonsterStat {
 #[derive(Clone)]
 pub struct TrioStat {
     pub ids: [u32; 3],
+    pub count: u32,
+    pub win_rate: f32,
+}
+
+/// Monstre compagnon dérivé d'un trio : 4e/5e pick fréquent.
+/// `count` = somme des co-occurrences, `win_rate` = WR moyen pondéré des sous-trios.
+#[derive(Clone)]
+pub struct Companion {
+    pub id: u32,
     pub count: u32,
     pub win_rate: f32,
 }

--- a/src/commands/rta_core/models.rs
+++ b/src/commands/rta_core/models.rs
@@ -1,22 +1,43 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, poise::ChoiceParameter)]
-pub enum Mode {
-    MetaSlayer,
-    FunAndCasual,
+pub enum Rank {
+    #[name = "P1"]
+    P1,
+    #[name = "P2-P3"]
+    P2P3,
+    #[name = "G1-G3"]
+    G1G2G3,
+    #[name = "G3"]
+    G3,
+}
+
+impl Rank {
+    pub fn lucksack_rank(&self) -> i32 {
+        match self {
+            Rank::P1 => 11,
+            Rank::P2P3 => 103,
+            Rank::G1G2G3 => 102,
+            Rank::G3 => 16,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Rank::P1 => "P1",
+            Rank::P2P3 => "P2-P3",
+            Rank::G1G2G3 => "G1-G3",
+            Rank::G3 => "G3",
+        }
+    }
 }
 
 #[derive(Debug, poise::ChoiceParameter)]
-pub enum Rank {
-    C1,
-    C2,
-    C3,
-    P1,
-    P2,
-    P3,
-    G1,
-    G2,
-    G3,
+pub enum Sort {
+    #[name = "Most Played"]
+    MostPlayed,
+    #[name = "Best Winrate"]
+    BestWinrate,
 }
 
 /// Représente une entrée brute du fichier monsters.json
@@ -82,32 +103,50 @@ pub struct MonsterStat {
     pub last_pick_total: u32,
 }
 
-/// Représente une entrée de la réponse highdata (duo pour un monstre de base)
-#[derive(Deserialize, Clone)]
-pub struct MonsterDuoStat {
-    #[serde(rename = "teamMonsterOneId")]
-    pub team_one_id: u32,
-    // #[serde(rename = "teamOneImgFilename")]
-    // pub team_one_img: String,
-    #[serde(rename = "teamMonsterTwoId")]
-    pub team_two_id: u32,
-    // #[serde(rename = "teamTwoImgFilename")]
-    // pub team_two_img: String,
-    // #[serde(rename = "winTotal")]
-    // pub win_total: u32,
-    #[serde(rename = "pickTotal")]
-    pub pick_total: u32,
-    #[serde(rename = "winRate")]
-    pub win_rate: String,
+/// Modèle local normalisé pour un trio
+#[derive(Clone)]
+pub struct TrioStat {
+    pub ids: [u32; 3],
+    pub count: u32,
+    pub win_rate: f32,
 }
 
-/// Modèle local pour un trio, avec métrique pondérée
-pub struct Trio {
-    pub base: u32,
-    pub one: u32,
-    pub two: u32,
-    pub win_rate: f32,          // ex. 0.55
-    pub pick_total: u32,        // ex. 1432
-    pub weighted_score: f32,    // win_rate * pick_total
-    pub emojis: Option<String>, // emojis
+/// Réponse statistics/trio
+#[derive(Deserialize, Clone)]
+pub struct LucksackTrioResponse {
+    pub records: Vec<LucksackTrioRecord>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct LucksackTrioRecord {
+    pub monster_id: Vec<u32>,
+    pub played_count: u32,
+    pub win_rate: f32,
+}
+
+/// Réponse monsters/{id}/with-trio
+#[derive(Deserialize, Clone)]
+pub struct LucksackWithTrioResponse {
+    pub records: Vec<LucksackWithTrioRecord>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct LucksackWithTrioRecord {
+    pub units1: LucksackUnitRef,
+    pub units2: LucksackUnitRef,
+    pub units3: LucksackUnitRef,
+    pub appearances: u32,
+    pub winrate: f32,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct LucksackUnitRef {
+    pub monster_id: u32,
+}
+
+/// Réponse patches
+#[derive(Deserialize, Clone)]
+pub struct LucksackPatch {
+    pub patch_id: i32,
+    pub patch_order: i32,
 }

--- a/src/commands/rta_core/utils.rs
+++ b/src/commands/rta_core/utils.rs
@@ -21,8 +21,13 @@ use std::fs;
 /// Nombre maximal de pages (100 trios chacune) récupérées par appel Lucksack.
 const MAX_TRIO_PAGES: i32 = 15;
 
-/// Lit le JSON dynamique (upload), extrait les unit_master_id,
-/// puis charge monsters.json et renvoie les Monster correspondants.
+/// Construit la box jouable à partir d'un export SW. Source = roster réelle
+/// (`unit_list`, toutes étoiles) **∪** nat5 possédés d'après le bestiaire
+/// (`unit_collection`, `open == 1`). Les nat5 étant indestructibles (non
+/// nourrissables/sacrifiables), `open == 1` y est une possession fiable, ce qui
+/// rattrape les nat5 de storage absents d'un export partiel. Toute unité non
+/// éveillée est mappée vers sa forme éveillée (id éveillé = id non éveillé + 10),
+/// car Lucksack indexe ses statistiques sur l'id éveillé.
 pub fn get_monsters_from_json_bytes(
     upload_bytes: &[u8],
     monsters_json_path: &str,
@@ -31,12 +36,12 @@ pub fn get_monsters_from_json_bytes(
     let dynamic: Value =
         serde_json::from_slice(upload_bytes).context("Failed to parse uploaded JSON")?;
 
-    // 2) Extraire la liste des unit_master_id
+    // 2) Roster réelle : unit_master_id de unit_list
     let unit_list = dynamic
         .get("unit_list")
         .and_then(|v| v.as_array())
         .context("Champ unit_list introuvable ou pas un tableau")?;
-    let wanted_ids: HashSet<u32> = unit_list
+    let roster_ids: HashSet<u32> = unit_list
         .iter()
         .filter_map(|u| {
             u.get("unit_master_id")?
@@ -45,31 +50,54 @@ pub fn get_monsters_from_json_bytes(
         })
         .collect();
 
+    // 2b) Bestiaire : monstres marqués possédés (open == 1). Fiable uniquement
+    //     pour les nat5 (filtrage par étoiles fait à l'étape 4).
+    let collection_ids: HashSet<u32> = dynamic
+        .get("unit_collection")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|c| c.get("open").and_then(|o| o.as_i64()) == Some(1))
+                .filter_map(|c| {
+                    c.get("unit_master_id")?
+                        .as_u64()
+                        .map(|id| remap_monster_id(id as i32) as u32)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     // 3) Lire et parser monsters.json
     let monsters_data =
         fs::read_to_string(monsters_json_path).context("Impossible de lire monsters.json")?;
     let all: MonstersFile =
         serde_json::from_str(&monsters_data).context("Impossible de parser monsters.json")?;
 
-    // 4) Filtrer selon unit_list **et** vos critères d’éveil / étoiles
+    // 4) Ne garder que les formes ÉVEILLÉES 3★+ élémentaires possédées.
     let result = all
         .monsters
         .into_iter()
         .filter(|m: &MonsterEntry| {
-            // doit appartenir à unit_list
-            if !wanted_ids.contains(&m.com2us_id) {
+            // forme éveillée, élémentaire, 3★+
+            if m.awaken_level < 1 || m.natural_stars < 3 {
                 return false;
             }
-            // awaken_level ≥ 1
-            if m.awaken_level < 1 {
+            if !matches!(
+                m.element.as_str(),
+                "Fire" | "Water" | "Wind" | "Light" | "Dark"
+            ) {
                 return false;
             }
-            // règle par élément
-            match m.element.as_str() {
-                "Fire" | "Water" | "Wind" => m.natural_stars >= 3,
-                "Light" | "Dark" => m.natural_stars >= 3,
-                _ => false,
-            }
+            // id non éveillé correspondant (id éveillé - 10)
+            let base = m.com2us_id.checked_sub(10);
+            // possédée dans la roster (forme éveillée ou non)
+            let in_roster =
+                roster_ids.contains(&m.com2us_id) || base.is_some_and(|b| roster_ids.contains(&b));
+            // nat5 possédée d'après le bestiaire (open == 1, fiable car indestructible)
+            let in_collection_nat5 = m.natural_stars == 5
+                && (collection_ids.contains(&m.com2us_id)
+                    || base.is_some_and(|b| collection_ids.contains(&b)));
+            in_roster || in_collection_nat5
         })
         .map(|m| Monster {
             unit_master_id: m.com2us_id,

--- a/src/commands/rta_core/utils.rs
+++ b/src/commands/rta_core/utils.rs
@@ -1,7 +1,9 @@
 use crate::commands::mob_stats::utils::remap_monster_id;
 use crate::commands::rta_core::models::{
-    Monster, MonsterDuoStat, MonsterEntry, MonstersFile, TierListData,
+    LucksackPatch, LucksackTrioRecord, LucksackTrioResponse, LucksackWithTrioResponse, Monster,
+    MonsterEntry, MonstersFile, TierListData, TrioStat,
 };
+use crate::commands::shared::clients::http_client;
 use anyhow::{Context, Result};
 use chrono::NaiveDate;
 use mongodb::{bson::doc, Collection};
@@ -9,6 +11,9 @@ use reqwest::Client;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::fs;
+
+/// Nombre maximal de pages (100 trios chacune) récupérées par appel Lucksack.
+const MAX_TRIO_PAGES: i32 = 15;
 
 /// Lit le JSON dynamique (upload), extrait les unit_master_id,
 /// puis charge monsters.json et renvoie les Monster correspondants.
@@ -121,94 +126,155 @@ pub async fn get_tierlist_data(api_level: i32, token: &str) -> Result<TierListDa
     Ok(tierlist_data)
 }
 
-pub async fn get_swrt_version(token: &str) -> Result<String, String> {
-    let url = "https://m.swranking.com/api/setting/settingMap";
+/// Récupère le dernier patch d'une saison Lucksack (celui avec le patch_order maximal).
+pub async fn get_latest_patch(season: i32) -> Result<i32, String> {
+    let url = format!("https://api.lucksack.gg/seasons/{}/patches", season);
 
-    let client = Client::new();
-    let response = client
-        .get(url)
-        .header("Authentication", token)
-        .header("Referer", "https://m.swranking.com/")
-        .header("User-Agent", "Mozilla/5.0")
-        .send()
-        .await
-        .map_err(|_| "Failed get settings".to_string())?;
-
-    let json = response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(|_| "Failed to parse settings JSON".to_string())?;
-
-    let version_str = json["data"]["nowVersion"]
-        .as_str()
-        .ok_or("Missing nowVersion".to_string())?;
-
-    Ok(version_str.to_string())
-}
-
-/// Récupère les duos (highOneWithTwoList) pour un monstre donné
-pub async fn get_monster_duos(
-    token: &str,
-    season: i64,
-    version: &str,
-    monster_id: u32,
-    level: i32,
-) -> Result<Vec<MonsterDuoStat>> {
-    let url = format!(
-        "https://m.swranking.com/api/monster/highdata?pageNum=1&pageSize=20&monsterId={}&season={}&version={}&level={}&factor=0.01&real=0",
-        monster_id, season, version, level
-    );
-    let client = Client::new();
-    let resp = client
+    let res = http_client()
         .get(&url)
-        .header("Authentication", token)
-        .header("Referer", "https://m.swranking.com/")
-        .header("User-Agent", "Mozilla/5.0")
+        .header("user-agent", "Mozilla/5.0 (X11; Linux x86_64)")
+        .header("sec-fetch-site", "none")
         .send()
-        .await?
-        .json::<Value>()
-        .await?;
-    let list = resp["data"]["highOneWithTwoList"]
-        .as_array()
-        .context("Missing highOneWithTwoList")?;
-    let duos = serde_json::from_value(Value::Array(list.clone()))?;
-    Ok(duos)
+        .await
+        .map_err(|_| "Failed to send request".to_string())?;
+
+    if !res.status().is_success() {
+        return Err(format!("HTTP {}", res.status()));
+    }
+
+    let patches = res
+        .json::<Vec<LucksackPatch>>()
+        .await
+        .map_err(|_| "Failed to parse patches JSON".to_string())?;
+
+    patches
+        .into_iter()
+        .max_by_key(|p| p.patch_order)
+        .map(|p| p.patch_id)
+        .ok_or_else(|| "No patch found".to_string())
 }
 
-pub fn filter_monster(tierlist_data: &TierListData, monsters: &[Monster]) -> TierListData {
-    let mut filtered_tierlist = tierlist_data.clone();
-    filtered_tierlist.sss_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.ss_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.s_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.a_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.b_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
-    filtered_tierlist.c_monster.retain(|m| {
-        monsters
-            .iter()
-            .any(|monster| monster.unit_master_id == m.monster_id)
-    });
+/// Récupère les trios globaux d'un rank pour une saison/patch, filtrés localement
+/// par min_games (statistics/trio ne supporte pas min_appearances).
+pub async fn fetch_global_trios(
+    season: i32,
+    patch: i32,
+    rank: i32,
+    min_games: u32,
+) -> Result<Vec<TrioStat>, String> {
+    let mut result: Vec<TrioStat> = Vec::new();
 
-    filtered_tierlist
+    for page in 0..MAX_TRIO_PAGES {
+        let offset = page * 100;
+        let url = format!(
+            "https://api.lucksack.gg/statistics/trio?season={}&rank={}&patch={}&limit=100&offset={}&order_by=Pick&order_direction=Desc",
+            season, rank, patch, offset
+        );
+
+        let res = http_client()
+            .get(&url)
+            .header("user-agent", "Mozilla/5.0 (X11; Linux x86_64)")
+            .header("sec-fetch-site", "none")
+            .send()
+            .await
+            .map_err(|_| "Failed to send request".to_string())?;
+
+        if !res.status().is_success() {
+            return Err(format!("HTTP {}", res.status()));
+        }
+
+        let body = res
+            .json::<LucksackTrioResponse>()
+            .await
+            .map_err(|_| "Failed to parse trio JSON".to_string())?;
+
+        let page_len = body.records.len();
+
+        for record in body.records {
+            let LucksackTrioRecord {
+                monster_id,
+                played_count,
+                win_rate,
+            } = record;
+
+            if monster_id.len() != 3 {
+                continue;
+            }
+
+            if played_count < min_games {
+                continue;
+            }
+
+            result.push(TrioStat {
+                ids: [monster_id[0], monster_id[1], monster_id[2]],
+                count: played_count,
+                win_rate,
+            });
+        }
+
+        if page_len < 100 {
+            break;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Récupère les trios contenant un monstre donné. min_games est appliqué côté serveur
+/// via min_appearances.
+pub async fn fetch_monster_trios(
+    season: i32,
+    patch: i32,
+    rank: i32,
+    monster_id: u32,
+    min_games: u32,
+) -> Result<Vec<TrioStat>, String> {
+    let mut result: Vec<TrioStat> = Vec::new();
+
+    for page in 0..MAX_TRIO_PAGES {
+        let offset = page * 100;
+        let url = format!(
+            "https://api.lucksack.gg/monsters/{}/with-trio?season={}&rank={}&patch={}&limit=100&offset={}&order_by=appearances&order_direction=desc&min_appearances={}",
+            monster_id, season, rank, patch, offset, min_games
+        );
+
+        let res = http_client()
+            .get(&url)
+            .header("user-agent", "Mozilla/5.0 (X11; Linux x86_64)")
+            .header("sec-fetch-site", "none")
+            .send()
+            .await
+            .map_err(|_| "Failed to send request".to_string())?;
+
+        if !res.status().is_success() {
+            return Err(format!("HTTP {}", res.status()));
+        }
+
+        let body = res
+            .json::<LucksackWithTrioResponse>()
+            .await
+            .map_err(|_| "Failed to parse with-trio JSON".to_string())?;
+
+        let page_len = body.records.len();
+
+        for record in body.records {
+            result.push(TrioStat {
+                ids: [
+                    record.units1.monster_id,
+                    record.units2.monster_id,
+                    record.units3.monster_id,
+                ],
+                count: record.appearances,
+                win_rate: record.winrate,
+            });
+        }
+
+        if page_len < 100 {
+            break;
+        }
+    }
+
+    Ok(result)
 }
 
 pub async fn get_emoji_from_id(

--- a/src/commands/rta_core/utils.rs
+++ b/src/commands/rta_core/utils.rs
@@ -1,15 +1,21 @@
 use crate::commands::mob_stats::utils::remap_monster_id;
 use crate::commands::rta_core::models::{
-    LucksackPatch, LucksackTrioRecord, LucksackTrioResponse, LucksackWithTrioResponse, Monster,
-    MonsterEntry, MonstersFile, TierListData, TrioStat,
+    Companion, LucksackPatch, LucksackTrioRecord, LucksackTrioResponse, LucksackWithTrioResponse,
+    Monster, MonsterEntry, MonstersFile, Sort, TierListData, TrioStat,
 };
 use crate::commands::shared::clients::http_client;
 use anyhow::{Context, Result};
 use chrono::NaiveDate;
+use futures::stream::TryStreamExt;
 use mongodb::{bson::doc, Collection};
+use poise::serenity_prelude as serenity;
 use reqwest::Client;
 use serde_json::Value;
-use std::collections::HashSet;
+use serenity::builder::{
+    CreateActionRow, CreateEmbed, CreateEmbedFooter, CreateSelectMenu, CreateSelectMenuOption,
+};
+use serenity::CreateSelectMenuKind;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 
 /// Nombre maximal de pages (100 trios chacune) récupérées par appel Lucksack.
@@ -296,4 +302,306 @@ pub async fn get_emoji_from_id(
     // println!("Extracted emoji_id: {}, emoji_name: {}", emoji_id, emoji_name);
 
     Some(format!("<:{}:{}>", emoji_name, emoji_id))
+}
+
+/// Charge toute la collection mob-emoji en `HashMap<com2us_id, "<:name:id>">`,
+/// pour éviter un `find_one` par monstre à chaque rendu interactif.
+pub async fn load_all_mob_emojis(
+    collection: &Collection<mongodb::bson::Document>,
+) -> HashMap<u32, String> {
+    let mut map = HashMap::new();
+    let Ok(mut cursor) = collection.find(doc! {}).await else {
+        return map;
+    };
+    while let Ok(Some(d)) = cursor.try_next().await {
+        let com2us_id = d
+            .get_i64("com2us_id")
+            .ok()
+            .map(|v| v as u32)
+            .or_else(|| d.get_i32("com2us_id").ok().map(|v| v as u32));
+        let (Some(id), Ok(emoji_id), Ok(emoji_name)) =
+            (com2us_id, d.get_str("id"), d.get_str("name"))
+        else {
+            continue;
+        };
+        map.insert(id, format!("<:{}:{}>", emoji_name, emoji_id));
+    }
+    map
+}
+
+/// Dérive les compagnons (4e/5e picks) d'un trio à partir du pool déjà récupéré :
+/// un trio du pool partageant exactement 2 membres avec `{A,B,C}` révèle son 3e
+/// membre comme compagnon. Aucun appel réseau. Exclut les membres du trio et
+/// le monstre `exclude` éventuel. `count` = somme des co-occurrences.
+pub fn derive_companions(
+    pool: &[TrioStat],
+    trio: [u32; 3],
+    exclude: Option<u32>,
+    max: usize,
+) -> Vec<Companion> {
+    let mut agg: HashMap<u32, (u64, f64)> = HashMap::new();
+    for t in pool {
+        let shared = t.ids.iter().filter(|id| trio.contains(id)).count();
+        if shared != 2 {
+            continue;
+        }
+        let Some(other) = t.ids.iter().copied().find(|id| !trio.contains(id)) else {
+            continue;
+        };
+        if Some(other) == exclude {
+            continue;
+        }
+        let entry = agg.entry(other).or_insert((0, 0.0));
+        entry.0 += t.count as u64;
+        entry.1 += t.win_rate as f64 * t.count as f64;
+    }
+
+    let mut companions: Vec<Companion> = agg
+        .into_iter()
+        .map(|(id, (count, wr_sum))| Companion {
+            id,
+            count: count.min(u32::MAX as u64) as u32,
+            win_rate: if count > 0 {
+                (wr_sum / count as f64) as f32
+            } else {
+                0.0
+            },
+        })
+        .collect();
+    companions.sort_by_key(|c| std::cmp::Reverse(c.count));
+    companions.truncate(max);
+    companions
+}
+
+/// Sections affichées selon le tri demandé : sans tri, 5 Most Played + 5 Best Winrate ;
+/// avec tri, une seule section de 10. Tuple = (titre, icône, trios).
+pub fn build_sections(
+    playable: &[TrioStat],
+    sort: Option<&Sort>,
+) -> Vec<(&'static str, &'static str, Vec<TrioStat>)> {
+    match sort {
+        None => vec![
+            ("Most Played", "🔥", top_by_count(playable, 5)),
+            ("Best Winrate", "🏆", top_by_wr(playable, 5)),
+        ],
+        Some(Sort::MostPlayed) => vec![("Most Played", "🔥", top_by_count(playable, 10))],
+        Some(Sort::BestWinrate) => vec![("Best Winrate", "🏆", top_by_wr(playable, 10))],
+    }
+}
+
+fn top_by_count(playable: &[TrioStat], n: usize) -> Vec<TrioStat> {
+    let mut v = playable.to_vec();
+    v.sort_by_key(|t| std::cmp::Reverse(t.count));
+    v.truncate(n);
+    v
+}
+
+fn top_by_wr(playable: &[TrioStat], n: usize) -> Vec<TrioStat> {
+    let mut v = playable.to_vec();
+    v.sort_by(|a, b| {
+        b.win_rate
+            .partial_cmp(&a.win_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    v.truncate(n);
+    v
+}
+
+fn short_name(full: &str) -> String {
+    full.split(" - ").next().unwrap_or(full).to_string()
+}
+
+fn emoji_or_fallback(
+    emoji_map: &HashMap<u32, String>,
+    id_to_name: &HashMap<u32, String>,
+    id: u32,
+) -> String {
+    if let Some(e) = emoji_map.get(&id) {
+        e.clone()
+    } else if let Some(name) = id_to_name.get(&id) {
+        short_name(name)
+    } else {
+        "❓".to_string()
+    }
+}
+
+/// Étoiles de popularité relatives au compagnon le plus fréquent (5★ = max).
+fn companion_stars(count: u32, max_count: u32) -> String {
+    if max_count == 0 {
+        return "☆☆☆☆☆".to_string();
+    }
+    let ratio = (count as f32 / max_count as f32).clamp(0.0, 1.0);
+    let full = ((ratio * 5.0).round() as usize).clamp(1, 5);
+    format!("{}{}", "★".repeat(full), "☆".repeat(5 - full))
+}
+
+/// Convertit "<:name:id>" en ReactionType::Custom pour l'emoji d'une option de menu.
+fn custom_emoji_reaction(render: &str) -> Option<serenity::ReactionType> {
+    let inner = render.strip_prefix("<:")?.strip_suffix('>')?;
+    let (name, id) = inner.rsplit_once(':')?;
+    let id: u64 = id.parse().ok()?;
+    Some(serenity::ReactionType::Custom {
+        animated: false,
+        id: id.into(),
+        name: Some(name.to_string()),
+    })
+}
+
+/// Joint des lignes en respectant un budget de caractères (limite de champ Discord).
+fn join_within(lines: &[String], max: usize) -> String {
+    let mut out = String::new();
+    for line in lines {
+        let extra = line.chars().count() + usize::from(!out.is_empty());
+        if out.chars().count() + extra > max {
+            break;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// Construit l'embed principal de /get_rta_core. Rendu synchrone (emoji_map préchargé).
+#[allow(clippy::too_many_arguments)]
+pub fn build_rta_core_embed(
+    wizard_name: &str,
+    rank_label: &str,
+    focus_name: Option<&str>,
+    exclude_name: Option<&str>,
+    playable_count: usize,
+    sections: &[(&'static str, &'static str, Vec<TrioStat>)],
+    emoji_map: &HashMap<u32, String>,
+    id_to_name: &HashMap<u32, String>,
+    box_ids: &HashSet<u32>,
+    selected: Option<&([u32; 3], Vec<Companion>)>,
+) -> CreateEmbed {
+    let mut embed = CreateEmbed::default()
+        .title(format!("🎯 Trios for {} — {}", wizard_name, rank_label))
+        .color(serenity::Colour::from_rgb(120, 153, 255))
+        .footer(CreateEmbedFooter::new(format!(
+            "Data from lucksack.gg · {} playable trios",
+            playable_count
+        )));
+
+    let mut desc = String::new();
+    if let Some(f) = focus_name {
+        desc.push_str(&format!("🔎 Focusing on **{}**\n", short_name(f)));
+    }
+    if let Some(e) = exclude_name {
+        desc.push_str(&format!("🚫 Excluding **{}**\n", short_name(e)));
+    }
+    if !desc.is_empty() {
+        embed = embed.description(desc);
+    }
+
+    for (title, icon, trios) in sections {
+        let value = if trios.is_empty() {
+            "- No Trio Found".to_string()
+        } else {
+            let lines: Vec<String> = trios
+                .iter()
+                .map(|t| {
+                    format!(
+                        "{} {} {} → **{:.1} %** WR ({})",
+                        emoji_or_fallback(emoji_map, id_to_name, t.ids[0]),
+                        emoji_or_fallback(emoji_map, id_to_name, t.ids[1]),
+                        emoji_or_fallback(emoji_map, id_to_name, t.ids[2]),
+                        t.win_rate * 100.0,
+                        t.count
+                    )
+                })
+                .collect();
+            join_within(&lines, 1024)
+        };
+        embed = embed.field(format!("{} {}", icon, title), value, false);
+    }
+
+    if let Some((trio, companions)) = selected {
+        let header = format!(
+            "🧩 Companions for {} {} {}",
+            emoji_or_fallback(emoji_map, id_to_name, trio[0]),
+            emoji_or_fallback(emoji_map, id_to_name, trio[1]),
+            emoji_or_fallback(emoji_map, id_to_name, trio[2]),
+        );
+        let value = if companions.is_empty() {
+            "No reliable companion data for this trio.".to_string()
+        } else {
+            let max_count = companions.iter().map(|c| c.count).max().unwrap_or(0);
+            let mut lines: Vec<String> = companions
+                .iter()
+                .map(|c| {
+                    let badge = if box_ids.contains(&c.id) {
+                        "✅"
+                    } else {
+                        "❌"
+                    };
+                    format!(
+                        "{} {}  {} · {:.0}% WR",
+                        emoji_or_fallback(emoji_map, id_to_name, c.id),
+                        badge,
+                        companion_stars(c.count, max_count),
+                        c.win_rate * 100.0
+                    )
+                })
+                .collect();
+            lines.push("✅ = in your box · ❌ = missing".to_string());
+            join_within(&lines, 1024)
+        };
+        embed = embed.field(header, value, false);
+    }
+
+    embed
+}
+
+/// Menu de sélection listant les trios affichés (dédupliqués). Sélectionner un trio
+/// déclenche l'affichage de ses compagnons. Valeur de l'option = "id_id_id".
+pub fn build_trio_select_menu(
+    displayed: &[TrioStat],
+    emoji_map: &HashMap<u32, String>,
+    id_to_name: &HashMap<u32, String>,
+) -> Option<CreateActionRow> {
+    if displayed.is_empty() {
+        return None;
+    }
+    let mut seen: HashSet<[u32; 3]> = HashSet::new();
+    let mut options: Vec<CreateSelectMenuOption> = Vec::new();
+    for t in displayed {
+        let mut key = t.ids;
+        key.sort_unstable();
+        if !seen.insert(key) {
+            continue;
+        }
+        let value = format!("{}_{}_{}", t.ids[0], t.ids[1], t.ids[2]);
+        let label: String = format!(
+            "{} + {} + {}",
+            short_name(id_to_name.get(&t.ids[0]).map(|s| s.as_str()).unwrap_or("?")),
+            short_name(id_to_name.get(&t.ids[1]).map(|s| s.as_str()).unwrap_or("?")),
+            short_name(id_to_name.get(&t.ids[2]).map(|s| s.as_str()).unwrap_or("?")),
+        )
+        .chars()
+        .take(100)
+        .collect();
+
+        let mut option = CreateSelectMenuOption::new(label, value);
+        if let Some(reaction) = emoji_map
+            .get(&t.ids[0])
+            .and_then(|e| custom_emoji_reaction(e))
+        {
+            option = option.emoji(reaction);
+        }
+        options.push(option);
+        if options.len() >= 25 {
+            break;
+        }
+    }
+
+    let menu = CreateSelectMenu::new(
+        "rta_core_trio_select",
+        CreateSelectMenuKind::String { options },
+    )
+    .placeholder("Pick a trio to reveal its 4th/5th picks");
+
+    Some(CreateActionRow::SelectMenu(menu))
 }


### PR DESCRIPTION
## Résumé

Rend la commande `/get_rta_core` interactive et ajoute la dérivation des **monstres compagnons (4e/5e picks)** d'un trio.

> ⚠️ **Empilée sur #75** (migration `/get_rta_core` vers Lucksack). Tant que #75 n'est pas mergée, le diff ci-dessous inclut aussi la migration ; il se réduira aux changements « compagnons » une fois #75 fusionnée. À relire après #75.

## Changements

- **Embed interactif** : la réponse passe du texte brut à un `CreateEmbed`, avec une boucle `ComponentInteractionCollector` (filtrée sur l'utilisateur, timeout 600 s).
- **Boutons de rang** (P1 / P2-P3 / G1-G3 / G3) : rebascule de bracket **sans re-uploader** le fichier (réutilise `create_lucksack_rank_buttons`).
- **Menu de sélection des trios** : choisir un trio affiché révèle un champ « 🧩 Companions » listant les 4e/5e picks les plus fréquents, avec étoiles de popularité + winrate et un badge ✅ (possédé) / ❌ (manquant dans la box).
- **Dérivation sans appel réseau** : les compagnons sont calculés à partir du pool de trios déjà mis en cache (trios partageant exactement 2 membres avec le trio ciblé), pas de requête Lucksack supplémentaire.
- **Perf** : la collection d'emojis est chargée une seule fois en `HashMap<com2us_id, …>` pour des re-rendus rapides lors des changements de rang.
- README mis à jour ; harnais console `dryrun.rs` étendu pour afficher les compagnons.

## Vérification

`cargo fmt --all -- --check`, `cargo build` et `cargo clippy --all-targets --all-features -- -D warnings` passent (0 warning). Validé end-to-end sur une box réelle via `dryrun.rs` :

- Global G1-G3, top trio Vanessa/Christina/Velaska → compagnons **Eludia, Sonia, Carlos (manquants)**, Leo (possédé).
- Focus Velaska en P2-P3 → **Carlos (manquant, 100 %)**, Leo (possédé), Sonia/Nobara (manquants).

Le cas d'usage visé est capturé : un trio jouable 3/3 dont la composition complète exige des monstres absents de la box, désormais explicitement signalés.
